### PR TITLE
Fix NPE for sparse datasets where some blocks are not present

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5CellLoader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5CellLoader.java
@@ -54,7 +54,7 @@ public class N5CellLoader< T extends NativeType< T > > implements CellLoader< T 
 		final long[] gridPosition = new long[ interval.numDimensions() ];
 		for ( int d = 0; d < gridPosition.length; ++d )
 			gridPosition[ d ] = interval.min( d ) / cellDimensions[ d ];
-		DataBlock< ? > block;
+		final DataBlock< ? > block;
 		try
 		{
 			block = n5.readBlock( dataset, attributes, gridPosition );
@@ -64,7 +64,8 @@ public class N5CellLoader< T extends NativeType< T > > implements CellLoader< T 
 			throw new RuntimeException( e );
 		}
 
-		copyFromBlock.accept( interval, block );
+		if ( block != null )
+			copyFromBlock.accept( interval, block );
 	}
 
 	public static < T extends Type< T > > void burnIn( final RandomAccessibleInterval< T > source, final RandomAccessibleInterval< T > target )

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5CellLoader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5CellLoader.java
@@ -12,6 +12,7 @@ import org.janelia.saalfeldlab.n5.N5;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.cache.img.CellLoader;
+import net.imglib2.cache.img.SingleCellArrayImg;
 import net.imglib2.img.Img;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.Type;
@@ -48,7 +49,7 @@ public class N5CellLoader< T extends NativeType< T > > implements CellLoader< T 
 	}
 
 	@Override
-	public void load( final Img< T > interval )
+	public void load( final SingleCellArrayImg< T, ? > interval )
 	{
 		final long[] gridPosition = new long[ interval.numDimensions() ];
 		for ( int d = 0; d < gridPosition.length; ++d )

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/RandomAccessibleLoader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/RandomAccessibleLoader.java
@@ -4,7 +4,7 @@ import net.imglib2.Cursor;
 import net.imglib2.Interval;
 import net.imglib2.RandomAccessible;
 import net.imglib2.cache.img.CellLoader;
-import net.imglib2.img.Img;
+import net.imglib2.cache.img.SingleCellArrayImg;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.type.NativeType;
 import net.imglib2.util.Intervals;
@@ -31,7 +31,7 @@ public class RandomAccessibleLoader< T extends NativeType< T > > implements Cell
 	}
 
 	@Override
-	public void load( final Img< T > interval )
+	public void load( final SingleCellArrayImg< T, ? > interval )
 	{
 		for ( Cursor< T > s = Views.flatIterable( Views.interval( source, interval ) ).cursor(), t = interval.cursor(); s.hasNext(); )
 			t.next().set( s.next() );


### PR DESCRIPTION
Fixes NullPointerException for sparse datasets where some (empty) blocks are not present.

Also fixes mvn/Eclipse build error due to not matching type in the overridden function.
(I somehow don't have write access to the main repository and can't push directly)