### PR TITLE
Displacement field io with n5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,10 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-realtransform</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5DisplacementField.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5DisplacementField.java
@@ -133,21 +133,6 @@ public class N5DisplacementField
         return src_converted;
 	}
 	
-	public static final < T extends RealType< T > > RandomAccessibleInterval< T > vectorAxisLast3( RandomAccessibleInterval< T > source ) throws Exception
-	{
-		final int n = source.numDimensions();
-
-		if ( source.dimension( n - 1 ) == (n - 1) )
-			return source;
-		else if ( source.dimension( 0 ) == (n - 1) )
-		{
-			Views.permute( Views.permute( Views.permute( source, 0, 3 ), 0, 1 ), 1, 2 );
-		}
-		throw new Exception( 
-				String.format( "Displacement fields must store vector components in the first or last dimension. " + 
-						"Found a %d-d volume; expect size [%d,...] or [...,%d]", n, ( n - 1 ), ( n - 1 ) ) );
-	}
-	
 	public static final < T extends RealType< T > > RandomAccessibleInterval< T > vectorAxisLast( RandomAccessibleInterval< T > source ) throws Exception
 	{
 		final int n = source.numDimensions();
@@ -162,21 +147,6 @@ public class N5DisplacementField
 				component[ i ] = i - 1;
 
 			return permute( source, component );
-		}
-
-		throw new Exception( 
-				String.format( "Displacement fields must store vector components in the first or last dimension. " + 
-						"Found a %d-d volume; expect size [%d,...] or [...,%d]", n, ( n - 1 ), ( n - 1 ) ) );
-	}
-	
-	public static final < T extends RealType< T > > RandomAccessibleInterval< T > vectorAxisFirst3( RandomAccessibleInterval< T > source ) throws Exception
-	{
-		final int n = source.numDimensions();
-		if ( source.dimension( 0 ) == (n - 1) )
-			return source;
-		else if ( source.dimension( n - 1 ) == (n - 1) )
-		{
-			Views.permute( Views.permute( Views.permute( source, 0, 3 ), 1, 3 ), 2, 3 );
 		}
 
 		throw new Exception( 

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5DisplacementField.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5DisplacementField.java
@@ -23,6 +23,7 @@ import net.imglib2.realtransform.AffineTransform;
 import net.imglib2.realtransform.AffineTransform2D;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.realtransform.DeformationFieldTransform;
+import net.imglib2.realtransform.ExplicitInvertibleRealTransform;
 import net.imglib2.realtransform.InverseRealTransform;
 import net.imglib2.realtransform.InvertibleRealTransform;
 import net.imglib2.realtransform.InvertibleRealTransformSequence;
@@ -32,6 +33,7 @@ import net.imglib2.realtransform.RealTransformSequence;
 import net.imglib2.realtransform.RealViews;
 import net.imglib2.transform.integer.MixedTransform;
 import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.integer.IntType;
@@ -47,6 +49,12 @@ import net.imglib2.view.IntervalView;
 import net.imglib2.view.MixedTransformView;
 import net.imglib2.view.Views;
 
+/**
+ * Class with helper methods for saving displacement field transformations as N5 datasets.
+ * 
+ * @author John Bogovic
+ *
+ */
 public class N5DisplacementField
 {
 	public static final String MULTIPLIER_ATTR = "quantization_multiplier";
@@ -82,12 +90,24 @@ public class N5DisplacementField
 	    save( n5Writer, INVERSE_ATTR, affine.inverse(), inverseDfield, invspacing, blockSize, compression );
 	}
 
+    /**
+     * Saves an affine transform and deformation field into a specified n5 dataset.
+     *
+     *
+     * @param n5Writer
+     * @param dataset
+     * @param affine
+     * @param dfield
+     * @param spacing the pixel spacing (resolution) of the deformation field
+     * @param blockSize
+     * @param compression
+     */
 	public static final <T extends NativeType<T> & RealType<T>> void save(
+			final N5Writer n5Writer,
+			final String dataset,
 			final AffineGet affine,
 			final RandomAccessibleInterval< T > dfield,
 			final double[] spacing,
-			final N5Writer n5Writer,
-			final String dataset,
 			final int[] blockSize,
 			final Compression compression ) throws IOException
 	{
@@ -100,12 +120,30 @@ public class N5DisplacementField
 			n5Writer.setAttribute( dataset, SPACING_ATTR, spacing );
 	}
 
+    /**
+     * Saves an affine transform and quantized deformation field into a specified n5 dataset.
+     *
+     * The deformation field here is saved as an {@link IntegerType}
+     * which could compress better in some cases.  The multiplier from
+     * original values to compressed values is chosen as the smallest
+     * value that keeps the error (L2) between quantized and original vectors. 
+     *
+     * @param n5Writer
+     * @param dataset
+     * @param affine
+     * @param dfield
+     * @param spacing
+     * @param blockSize
+     * @param compression
+     * @param outputType
+     * @param maxError
+     */
 	public static final <T extends NativeType<T> & RealType<T>, Q extends NativeType<Q> & IntegerType<Q>> void save(
+			final N5Writer n5Writer,
+			final String dataset,
 			final AffineGet affine,
 			final RandomAccessibleInterval< T > dfield,
 			final double[] spacing,
-			final N5Writer n5Writer,
-			final String dataset,
 			final int[] blockSize,
 			final Compression compression, 
 			final Q outputType, 
@@ -118,6 +156,14 @@ public class N5DisplacementField
 			n5Writer.setAttribute( dataset, SPACING_ATTR, spacing );
 	}
 
+    /**
+     * Saves an affine transform as an attribute associated with an n5
+     * dataset.
+     *
+     * @param affine
+     * @param n5Writer
+     * @param dataset
+     */
 	public static final void saveAffine(
 			final AffineGet affine,
 			final N5Writer n5Writer,
@@ -127,6 +173,22 @@ public class N5DisplacementField
 			n5Writer.setAttribute( dataset, AFFINE_ATTR,  affine.getRowPackedCopy() );
 	}
 
+    /**
+     * Saves an affine transform and quantized deformation field into a specified n5 dataset.
+     *
+     * The deformation field here is saved as an {@link IntegerType}
+     * which could compress better in some cases.  The multiplier from
+     * original values to compressed values is chosen as the smallest
+     * value that keeps the error (L2) between quantized and original vectors. 
+     *
+     * @param n5Writer
+     * @param dataset
+     * @param source
+     * @param blockSize
+     * @param compression
+     * @param outputType
+     * @param maxError
+     */
 	public static final <T extends RealType<T>, Q extends NativeType<Q> & IntegerType<Q>> void saveQuantized(
 			final N5Writer n5Writer,
 			final String dataset,
@@ -160,6 +222,19 @@ public class N5DisplacementField
 		n5Writer.setAttribute( dataset, MULTIPLIER_ATTR, m );
 	}
 	
+
+    /**
+     * Opens a {@link RealTransform} from an n5 dataset as a
+     * displacement field.  The resulting transform is the concatenation
+     * of an affine transform and a {@link DeformationFieldTransform}.
+     *
+     * @param n5
+     * @param dataset
+     * @param inverse
+     * @param defaultType
+     * @param interpolator
+     * @return the transformation
+     */
 	public static final <T extends RealType<T> & NativeType<T>> RealTransform open( 
 			final N5Reader n5,
 			final String dataset,
@@ -172,7 +247,7 @@ public class N5DisplacementField
 
 		DeformationFieldTransform< T > dfield = new DeformationFieldTransform<>(
 				openCalibratedField( n5, dataset, interpolator, defaultType ));
-		
+
 		if( affine != null )
 		{
 			RealTransformSequence xfmSeq = new RealTransformSequence();
@@ -194,6 +269,15 @@ public class N5DisplacementField
 		}
 	}
 
+    /**
+     * Returns an {@link AffineGet} transform from pixel space to
+     * physical space, for the given n5 dataset, if present, null
+     * otherwise.
+     *
+     * @param n5
+     * @param dataset
+     * @return the affine transform
+     */
 	public static final AffineGet openPixelToPhysical( final N5Reader n5, final String dataset ) throws Exception
 	{
 		double[] spacing = n5.getAttribute( dataset, SPACING_ATTR, double[].class );
@@ -218,6 +302,13 @@ public class N5DisplacementField
 		return affineMtx;
 	}
 
+    /**
+     * Returns and affine transform stored as an attribute in an n5 dataset.
+     *
+     * @param n5
+     * @param dataset
+     * @return the affine
+     */
 	public static final AffineGet openAffine( final N5Reader n5, final String dataset ) throws Exception
 	{
 		double[] affineMtxRow = n5.getAttribute( dataset, AFFINE_ATTR, double[].class );
@@ -239,6 +330,18 @@ public class N5DisplacementField
 		return affineMtx;
 	}
 
+    /**
+     * Returns a deformation field from the given n5 dataset.
+     *
+     * If the data is an {@link IntegerType}, returns an un-quantized
+     * view of the dataset, otherwise, returns the raw {@link
+     * RandomAccessibleInterval}.
+     *
+     * @param n5
+     * @param dataset
+     * @param defaultType
+     * @return the deformation field as a RandomAccessibleInterval
+     */
 	@SuppressWarnings( "unchecked" )
 	public static final <T extends NativeType<T> & RealType<T>, Q extends NativeType<Q> & IntegerType<Q>> RandomAccessibleInterval< T > openField( 
 			final N5Reader n5,
@@ -268,6 +371,22 @@ public class N5DisplacementField
 		}
 	}
 
+    /**
+     * Returns a deformation field in physical coordinates as a {@link
+     * RealRandomAccessible} from an n5 dataset.
+     *
+     * Internally, opens the given n5 dataset as a {@link
+     * RandomAccessibleInterval}, un-quantizes if necessary, uses
+     * the input {@link InterpolatorFactory} for interpolation, and
+     * transforms to physical coordinates using the pixel spacing stored
+     * in the "spacing" attribute, if present.
+     *
+     * @param n5
+     * @param dataset
+     * @param interpolator
+     * @param defaultType
+     * @return the deformation field as a RealRandomAccessible
+     */
 	public static < T extends NativeType< T > & RealType< T > > RealRandomAccessible< T > openCalibratedField(
 			final N5Reader n5, final String dataset,
 			final InterpolatorFactory< T, RandomAccessible< T > > interpolator, 
@@ -290,12 +409,30 @@ public class N5DisplacementField
 		return dfieldReal;
 	}
 
+    /**
+     * Opens a transform from an n5 dataset using linear interpolation
+     * for the deformation field.
+     *
+     * @param n5
+     * @param dataset
+     * @param inverse
+     * @return the transform
+     */
 	public static < T extends NativeType< T > & RealType< T > > RealTransform open(
 			final N5Reader n5, final String dataset, boolean inverse ) throws Exception
 	{
 		return open( n5, dataset, inverse, new FloatType(), new NLinearInterpolatorFactory<FloatType>());
 	}
 
+    /**
+     * Returns a deformation field as a {@link RandomAccessibleInterval}, ensuring that
+     * the vector is stored in the last dimension.
+     *
+     * @param n5
+     * @param dataset
+     * @param defaultType
+     * @return the deformation field
+     */
 	public static final < T extends RealType<T> & NativeType<T> > RandomAccessibleInterval< T > openRaw(
 			final N5Reader n5,
 			final String dataset,
@@ -305,6 +442,16 @@ public class N5DisplacementField
         return vectorAxisLast( src );
 	}
 
+    /**
+     * Open a quantized (integer) {@link RandomAccessibleInterval} from an n5
+     * dataset.
+     *
+     * @param n5
+     * @param dataset
+     * @param defaultQuantizedType
+     * @param defaultType
+     * @return the un-quantized data
+     */
 	public static final <Q extends RealType<Q> & NativeType<Q>, T extends RealType<T>> RandomAccessibleInterval< T > openQuantized(
 			final N5Reader n5,
 			final String dataset,
@@ -332,10 +479,18 @@ public class N5DisplacementField
 				}
 			}, 
 			defaultType.copy());
-        
+ 
         return src_converted;
 	}
 
+    /**
+     * Returns a deformation field as a {@link RandomAccessibleInterval}
+     * with the vector stored in the last dimension.
+     *
+     * @param source
+     * @return the possibly permuted deformation field
+     * @throws Exception
+     */
 	public static final < T extends RealType< T > > RandomAccessibleInterval< T > vectorAxisLast( RandomAccessibleInterval< T > source ) throws Exception
 	{
 		final int n = source.numDimensions();
@@ -357,6 +512,14 @@ public class N5DisplacementField
 						"Found a %d-d volume; expect size [%d,...] or [...,%d]", n, ( n - 1 ), ( n - 1 ) ) );
 	}
 	
+    /**
+     * Returns a deformation field as a {@link RandomAccessibleInterval}
+     * with the vector stored in the first dimension.
+     *
+     * @param source
+     * @return the possibly permuted deformation field
+     * @throws Exception
+     */
 	public static final < T extends RealType< T > > RandomAccessibleInterval< T > vectorAxisFirst( RandomAccessibleInterval< T > source ) throws Exception
 	{
 		final int n = source.numDimensions();
@@ -380,6 +543,15 @@ public class N5DisplacementField
 						"Found a %d-d volume; expect size [%d,...] or [...,%d]", n, ( n - 1 ), ( n - 1 ) ) );
 	}
 
+    /**
+     * Permutes the dimensions of a {@link RandomAccessibleInterval}
+     * using the given permutation vector, where the ith value in p
+     * gives destination of the ith input dimension in the output. 
+     *
+     * @param source the source data
+     * @param p the permutation
+     * @return the permuted source
+     */
 	public static final < T > IntervalView< T > permute( RandomAccessibleInterval< T > source, int[] p )
 	{
 		final int n = source.numDimensions();
@@ -398,6 +570,14 @@ public class N5DisplacementField
 		return Views.interval( new MixedTransformView< T >( source, t ), min, max );
 	}
 
+    /**
+     * Returns a two element double array in which the first and second elements
+     * store the minimum and maximum values of the input {@link
+     * IterableInterval}, respectively.
+     *
+     * @param img the iterable interval
+     * @return the min and max values stored in a double array
+     */
 	public static <T extends RealType<T>> double[] getMinMax( IterableInterval<T> img )
 	{
 		double min = Double.MAX_VALUE;

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5DisplacementField.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5DisplacementField.java
@@ -23,7 +23,6 @@ import net.imglib2.realtransform.AffineTransform;
 import net.imglib2.realtransform.AffineTransform2D;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.realtransform.DeformationFieldTransform;
-import net.imglib2.realtransform.ExplicitInvertibleRealTransform;
 import net.imglib2.realtransform.InverseRealTransform;
 import net.imglib2.realtransform.InvertibleRealTransform;
 import net.imglib2.realtransform.InvertibleRealTransformSequence;
@@ -150,7 +149,7 @@ public class N5DisplacementField
 			final double maxError ) throws Exception
 	{
 		
-		saveQuantized( dfield, n5Writer, dataset, blockSize, compression, outputType, maxError );
+		saveQuantized( n5Writer, dataset, dfield, blockSize, compression, outputType, maxError );
 		saveAffine( affine, n5Writer, dataset );
 		if( spacing != null )
 			n5Writer.setAttribute( dataset, SPACING_ATTR, spacing );

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5DisplacementField.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5DisplacementField.java
@@ -1,0 +1,200 @@
+package org.janelia.saalfeldlab.n5.imglib2;
+
+import org.janelia.saalfeldlab.n5.Compression;
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.N5Writer;
+
+import net.imglib2.Cursor;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converter;
+import net.imglib2.converter.Converters;
+import net.imglib2.transform.integer.MixedTransform;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.MixedTransformView;
+import net.imglib2.view.Views;
+
+public class N5DisplacementField
+{
+	public static final String MULTIPLIER_ATTR = "quantization_multiplier";
+
+
+	public static final <T extends RealType<T>, Q extends NativeType<Q> & RealType<Q>> void saveQuantized(
+			RandomAccessibleInterval<T> source,
+			final N5Writer n5Writer,
+			final String dataset,
+			final int[] blockSize,
+			final Compression compression,
+			final Q outputType,
+            final double maxError ) throws Exception
+	{
+		RandomAccessibleInterval< T > source_permuted = vectorAxisFirst( source );
+		
+        // the value that should be mapped to the maxValue of the
+        // quantization type in order to ensure quantization error is
+        // below maxError
+		double max = 2 * maxError * ( outputType.getMaxValue() - 1 );
+		double m = (outputType.getMaxValue() - 1) / max;
+		
+//		System.out.println( "m : " + m );
+
+		RandomAccessibleInterval< Q > source_quant = Converters.convert(
+				source_permuted, 
+				new Converter<T, Q>()
+				{
+					@Override
+					public void convert(T input, Q output)
+					{
+						output.setReal( Math.round( input.getRealDouble() * m ));
+					}
+				}, 
+				outputType.copy());
+
+        N5Utils.save( source_quant, n5Writer, dataset, blockSize, compression);
+		n5Writer.setAttribute( dataset, MULTIPLIER_ATTR, 1 / m );
+	}
+	
+	public static final <Q extends RealType<Q> & NativeType<Q>, T extends RealType<T>> RandomAccessibleInterval< T > openQuantized(
+			final N5Reader n5,
+			final String dataset,
+			final Q defaultQuantizedType,
+			final T defaultType ) throws Exception
+	{
+        RandomAccessibleInterval< Q > src = N5Utils.open( n5, dataset, defaultQuantizedType  );
+        
+        // get the factor going from quantized to original values
+        Double mattr = n5.getAttribute( dataset, MULTIPLIER_ATTR, Double.TYPE );
+        final double m;
+        if( mattr != null )
+        	m = mattr.doubleValue();
+        else
+        	m = 1.0;
+
+        RandomAccessibleInterval< Q > src_perm = vectorAxisLast( src );
+        RandomAccessibleInterval< T > src_converted = Converters.convert(
+        	src_perm, 
+			new Converter<Q, T>()
+			{
+				@Override
+				public void convert(Q input, T output) {
+					output.setReal( input.getRealDouble() * m );
+				}
+			}, 
+			defaultType.copy());
+        
+        return src_converted;
+	}
+	
+	public static final < T extends RealType< T > > RandomAccessibleInterval< T > vectorAxisLast3( RandomAccessibleInterval< T > source ) throws Exception
+	{
+		final int n = source.numDimensions();
+
+		if ( source.dimension( n - 1 ) == (n - 1) )
+			return source;
+		else if ( source.dimension( 0 ) == (n - 1) )
+		{
+			Views.permute( Views.permute( Views.permute( source, 0, 3 ), 0, 1 ), 1, 2 );
+		}
+		throw new Exception( 
+				String.format( "Displacement fields must store vector components in the first or last dimension. " + 
+						"Found a %d-d volume; expect size [%d,...] or [...,%d]", n, ( n - 1 ), ( n - 1 ) ) );
+	}
+	
+	public static final < T extends RealType< T > > RandomAccessibleInterval< T > vectorAxisLast( RandomAccessibleInterval< T > source ) throws Exception
+	{
+		final int n = source.numDimensions();
+
+		if ( source.dimension( n - 1 ) == (n - 1) )
+			return source;
+		else if ( source.dimension( 0 ) == (n - 1) )
+		{
+			final int[] component = new int[ n ];
+			component[ 0 ] = n - 1;
+			for ( int i = 1; i < n; ++i )
+				component[ i ] = i - 1;
+
+			return permute( source, component );
+		}
+
+		throw new Exception( 
+				String.format( "Displacement fields must store vector components in the first or last dimension. " + 
+						"Found a %d-d volume; expect size [%d,...] or [...,%d]", n, ( n - 1 ), ( n - 1 ) ) );
+	}
+	
+	public static final < T extends RealType< T > > RandomAccessibleInterval< T > vectorAxisFirst3( RandomAccessibleInterval< T > source ) throws Exception
+	{
+		final int n = source.numDimensions();
+		if ( source.dimension( 0 ) == (n - 1) )
+			return source;
+		else if ( source.dimension( n - 1 ) == (n - 1) )
+		{
+			Views.permute( Views.permute( Views.permute( source, 0, 3 ), 1, 3 ), 2, 3 );
+		}
+
+		throw new Exception( 
+				String.format( "Displacement fields must store vector components in the first or last dimension. " + 
+						"Found a %d-d volume; expect size [%d,...] or [...,%d]", n, ( n - 1 ), ( n - 1 ) ) );
+	}
+	
+	public static final < T extends RealType< T > > RandomAccessibleInterval< T > vectorAxisFirst( RandomAccessibleInterval< T > source ) throws Exception
+	{
+		final int n = source.numDimensions();
+		
+		System.out.println("source2perm: " + Util.printInterval(source));
+
+		if ( source.dimension( 0 ) == (n - 1) )
+			return source;
+		else if ( source.dimension( n - 1 ) == (n - 1) )
+		{
+			final int[] component = new int[ n ];
+			component[ n - 1 ] = 0;
+			for ( int i = 0; i < n-1; ++i )
+				component[ i ] = i + 1;
+
+			return permute( source, component );
+		}
+
+		throw new Exception( 
+				String.format( "Displacement fields must store vector components in the first or last dimension. " + 
+						"Found a %d-d volume; expect size [%d,...] or [...,%d]", n, ( n - 1 ), ( n - 1 ) ) );
+	}
+
+	public static final < T > IntervalView< T > permute( RandomAccessibleInterval< T > source, int[] p )
+	{
+		final int n = source.numDimensions();
+
+		final long[] min = new long[ n ];
+		final long[] max = new long[ n ];
+		for ( int i = 0; i < n; ++i )
+		{
+			min[ p[ i ] ] = source.min( i );
+			max[ p[ i ] ] = source.max( i );
+		}
+
+		final MixedTransform t = new MixedTransform( n, n );
+		t.setComponentMapping( p );
+
+		return Views.interval( new MixedTransformView< T >( source, t ), min, max );
+	}
+
+	public static <T extends RealType<T>> double[] getMinMax( IterableInterval<T> img )
+	{
+		double min = Double.MAX_VALUE;
+		double max = Double.MIN_VALUE;
+		Cursor<T> c = img.cursor();
+		while( c.hasNext() )
+		{
+			double v = Math.abs( c.next().getRealDouble());
+			if( v > max )
+				max = v;
+			
+			if( v < min )
+				min = v;
+		}
+		return new double[]{ min, max };
+	}
+
+}


### PR DESCRIPTION
Adds `imglib2-realtransform` as a dependency. 

Provides options for quantizing a float- typed field using an integer type (e.g. short) to reduce resulting file sizes. Max quantization error is controlled, but no explicit effort is made to prevent the 'wrapping' of values.