### PR TITLE
Add methods for saving blocks without grid offset parameter

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
@@ -28,6 +28,7 @@ package org.janelia.saalfeldlab.n5.imglib2;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -875,9 +876,7 @@ public class N5Utils {
 			final long[] gridOffset) throws IOException {
 
 		source = Views.zeroMin(source);
-		final long[] dimensions = Intervals.dimensionsAsLongArray(source);
-
-		final int n = dimensions.length;
+		final int n = source.numDimensions();
 		final long[] max = Intervals.maxAsLongArray(source);
 		final long[] offset = new long[n];
 		final long[] gridPosition = new long[n];
@@ -910,6 +909,48 @@ public class N5Utils {
 				else
 					offset[d] = 0;
 			}
+		}
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} as an N5 dataset.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @param attributes
+	 * @throws IOException
+	 */
+	public static final <T extends NativeType<T>> void saveBlock(
+			final RandomAccessibleInterval<T> source,
+			final N5Writer n5,
+			final String dataset,
+			final DatasetAttributes attributes) throws IOException {
+
+		final int[] blockSize = attributes.getBlockSize();
+		final long[] gridOffset = new long[blockSize.length];
+		Arrays.setAll(gridOffset, d -> source.min(d) / blockSize[d]);
+		saveBlock(source, n5, dataset, attributes, gridOffset);
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} as an N5 dataset.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @throws IOException
+	 */
+	public static final <T extends NativeType<T>> void saveBlock(
+			final RandomAccessibleInterval<T> source,
+			final N5Writer n5,
+			final String dataset) throws IOException {
+
+		final DatasetAttributes attributes = n5.getDatasetAttributes(dataset);
+		if (attributes != null) {
+			saveBlock(source, n5, dataset, attributes);
+		} else {
+			throw new IOException("Dataset " + dataset + " does not exist.");
 		}
 	}
 
@@ -1040,9 +1081,7 @@ public class N5Utils {
 			final T defaultValue) throws IOException {
 
 		source = Views.zeroMin(source);
-		final long[] dimensions = Intervals.dimensionsAsLongArray(source);
-
-		final int n = dimensions.length;
+		final int n = source.numDimensions();
 		final long[] max = Intervals.maxAsLongArray(source);
 		final long[] offset = new long[n];
 		final long[] gridPosition = new long[n];
@@ -1077,6 +1116,60 @@ public class N5Utils {
 				else
 					offset[d] = 0;
 			}
+		}
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} into an N5 dataset at a given
+	 * offset. The offset is given in {@link DataBlock} grid coordinates and the
+	 * source is assumed to align with the {@link DataBlock} grid of the
+	 * dataset. Only {@link DataBlock DataBlocks} that contain values other than
+	 * a given default value are stored.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @param attributes
+	 * @param defaultValue
+	 * @throws IOException
+	 */
+	public static final <T extends NativeType<T>> void saveNonEmptyBlock(
+			final RandomAccessibleInterval<T> source,
+			final N5Writer n5,
+			final String dataset,
+			final DatasetAttributes attributes,
+			final T defaultValue) throws IOException {
+
+		final int[] blockSize = attributes.getBlockSize();
+		final long[] gridOffset = new long[blockSize.length];
+		Arrays.setAll(gridOffset, d -> source.min(d) / blockSize[d]);
+		saveNonEmptyBlock(source, n5, dataset, attributes, gridOffset, defaultValue);
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} into an N5 dataset at a given
+	 * offset. The offset is given in {@link DataBlock} grid coordinates and the
+	 * source is assumed to align with the {@link DataBlock} grid of the
+	 * dataset. Only {@link DataBlock DataBlocks} that contain values other than
+	 * a given default value are stored.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @param defaultValue
+	 * @throws IOException
+	 */
+	public static final <T extends NativeType<T>> void saveNonEmptyBlock(
+			final RandomAccessibleInterval<T> source,
+			final N5Writer n5,
+			final String dataset,
+			final T defaultValue) throws IOException {
+
+		final DatasetAttributes attributes = n5.getDatasetAttributes(dataset);
+		if (attributes != null) {
+			saveNonEmptyBlock(source, n5, dataset, attributes, defaultValue);
+		} else {
+			throw new IOException("Dataset " + dataset + " does not exist.");
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
@@ -859,7 +859,9 @@ public class N5Utils {
 	}
 
 	/**
-	 * Save a {@link RandomAccessibleInterval} as an N5 dataset.
+	 * Save a {@link RandomAccessibleInterval} into an N5 dataset at a given
+	 * offset. The offset is given in {@link DataBlock} grid coordinates and the
+	 * source is assumed to align with the {@link DataBlock} grid of the dataset.
 	 *
 	 * @param source
 	 * @param n5
@@ -913,7 +915,10 @@ public class N5Utils {
 	}
 
 	/**
-	 * Save a {@link RandomAccessibleInterval} as an N5 dataset.
+	 * Save a {@link RandomAccessibleInterval} into an N5 dataset.
+	 * The block offset is determined by the source position, and the
+	 * source is assumed to align with the {@link DataBlock} grid
+	 * of the dataset.
 	 *
 	 * @param source
 	 * @param n5
@@ -934,7 +939,10 @@ public class N5Utils {
 	}
 
 	/**
-	 * Save a {@link RandomAccessibleInterval} as an N5 dataset.
+	 * Save a {@link RandomAccessibleInterval} into an N5 dataset.
+	 * The block offset is determined by the source position, and the
+	 * source is assumed to align with the {@link DataBlock} grid
+	 * of the dataset.
 	 *
 	 * @param source
 	 * @param n5
@@ -955,7 +963,9 @@ public class N5Utils {
 	}
 
 	/**
-	 * Save a {@link RandomAccessibleInterval} as an N5 dataset.
+	 * Save a {@link RandomAccessibleInterval} into an N5 dataset at a given
+	 * offset. The offset is given in {@link DataBlock} grid coordinates and the
+	 * source is assumed to align with the {@link DataBlock} grid of the dataset.
 	 *
 	 * @param source
 	 * @param n5
@@ -1120,11 +1130,11 @@ public class N5Utils {
 	}
 
 	/**
-	 * Save a {@link RandomAccessibleInterval} into an N5 dataset at a given
-	 * offset. The offset is given in {@link DataBlock} grid coordinates and the
-	 * source is assumed to align with the {@link DataBlock} grid of the
-	 * dataset. Only {@link DataBlock DataBlocks} that contain values other than
-	 * a given default value are stored.
+	 * Save a {@link RandomAccessibleInterval} into an N5 dataset.
+	 * The block offset is determined by the source position, and the
+	 * source is assumed to align with the {@link DataBlock} grid
+	 * of the dataset. Only {@link DataBlock DataBlocks} that contain
+	 * values other than a given default value are stored.
 	 *
 	 * @param source
 	 * @param n5
@@ -1147,11 +1157,11 @@ public class N5Utils {
 	}
 
 	/**
-	 * Save a {@link RandomAccessibleInterval} into an N5 dataset at a given
-	 * offset. The offset is given in {@link DataBlock} grid coordinates and the
-	 * source is assumed to align with the {@link DataBlock} grid of the
-	 * dataset. Only {@link DataBlock DataBlocks} that contain values other than
-	 * a given default value are stored.
+	 * Save a {@link RandomAccessibleInterval} into an N5 dataset.
+	 * The block offset is determined by the source position, and the
+	 * source is assumed to align with the {@link DataBlock} grid
+	 * of the dataset. Only {@link DataBlock DataBlocks} that contain
+	 * values other than a given default value are stored.
 	 *
 	 * @param source
 	 * @param n5


### PR DESCRIPTION
New overloads of `saveBlock()` and `saveNonEmptyBlock()` simplify usage by calculating grid offset from the source position instead of taking it as a parameter.