### PR TITLE
Add support for label multisets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,11 +134,11 @@
 			<artifactId>n5</artifactId>
 			<version>2.0.2</version>
 		</dependency>
-		
+
 		<dependency>
-			<groupId>org.janelia.saalfeldlab</groupId>
-			<artifactId>label-multisets</artifactId>
-			<version>0.4.2-SNAPSHOT</version>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-label-multisets</artifactId>
+			<version>0.5.0</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,12 @@
 			<artifactId>n5</artifactId>
 			<version>2.0.2</version>
 		</dependency>
-
+		
+		<dependency>
+			<groupId>org.janelia.saalfeldlab</groupId>
+			<artifactId>label-multisets</artifactId>
+			<version>0.4.2-SNAPSHOT</version>
+		</dependency>
 
 		<dependency>
 			<groupId>net.imglib2</groupId>

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisetCacheLoader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisetCacheLoader.java
@@ -1,0 +1,178 @@
+package org.janelia.saalfeldlab.n5.imglib2;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.function.BiFunction;
+
+import org.janelia.saalfeldlab.n5.DataBlock;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.imglib2.img.cell.CellGrid;
+import net.imglib2.type.label.AbstractLabelMultisetLoader;
+import net.imglib2.type.label.ByteUtils;
+import net.imglib2.type.label.LabelMultisetEntry;
+import net.imglib2.type.label.LabelMultisetEntryList;
+import net.imglib2.type.label.LongMappedAccessData;
+
+public class N5LabelMultisetCacheLoader extends AbstractLabelMultisetLoader
+{
+
+	private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+	private final N5Reader n5;
+
+	private final String dataset;
+
+	private final BiFunction<CellGrid, long[], byte[]> nullReplacement;
+
+	public N5LabelMultisetCacheLoader(
+			final N5Reader n5,
+			final String dataset ) throws IOException
+	{
+		this( n5, dataset, (g, p) -> null );
+	}
+
+	public N5LabelMultisetCacheLoader(
+			final N5Reader n5,
+			final String dataset,
+			final BiFunction<CellGrid, long[], byte[]> nullReplacement ) throws IOException
+	{
+		super( generateCellGrid( n5, dataset ) );
+		this.n5 = n5;
+		this.dataset = dataset;
+		this.nullReplacement = nullReplacement;
+	}
+
+	public static BiFunction< CellGrid, long[], byte[] > constantNullReplacement( final long id )
+	{
+		return new ConstantNullReplacement( id );
+	}
+
+	private static CellGrid generateCellGrid( final N5Reader n5, final String dataset ) throws IOException
+	{
+		final DatasetAttributes attributes = n5.getDatasetAttributes( dataset );
+
+		final long[] dimensions = attributes.getDimensions();
+		final int[] cellDimensions = attributes.getBlockSize();
+
+		return new CellGrid( dimensions, cellDimensions );
+	}
+
+	@Override
+	protected byte[] getData( final long... gridPosition )
+	{
+		final DataBlock< ? > block;
+		try
+		{
+			LOG.debug( "Reading block for position {}", gridPosition );
+			block = n5.readBlock( dataset, n5.getDatasetAttributes( dataset ), gridPosition );
+			LOG.debug( "Read block for position {} {}", gridPosition, block );
+		}
+		catch ( final IOException e )
+		{
+			LOG.debug( "Caught exception while reading block", e );
+			throw new RuntimeException( e );
+		}
+		return block == null ? nullReplacement.apply( super.grid, gridPosition ): ( byte[] ) block.getData();
+	}
+
+	private static class ConstantNullReplacement implements BiFunction< CellGrid, long[], byte[] >
+	{
+
+		private final long id;
+
+		private ConstantNullReplacement( final long id )
+		{
+			this.id = id;
+		}
+
+		private static int numElements( final int[] size )
+		{
+			int n = 1;
+			for ( final int s : size )
+				n *= s;
+			return n;
+		}
+
+		//		final ByteBuffer bb = ByteBuffer.wrap( bytes );
+		//
+		//		final int argMaxSize = bb.getInt();
+		//		final long[] argMax = new long[ argMaxSize ];
+		//		for ( int i = 0; i < argMaxSize; ++i )
+		//		{
+		//			argMax[ i ] = bb.getLong();
+		//		}
+		//
+		//		final int[] data = new int[ numElements ];
+		//		final int listDataSize = bytes.length - ( AbstractLabelMultisetLoader.listOffsetsSizeInBytes( data.length )
+		//				+ AbstractLabelMultisetLoader.argMaxListSizeInBytes( argMax.length ) );
+		//		final LongMappedAccessData listData = LongMappedAccessData.factory.createStorage( listDataSize );
+		//
+		//		for ( int i = 0; i < data.length; ++i )
+		//		{
+		//			data[ i ] = bb.getInt();
+		//		}
+		//
+		//		for ( int i = 0; i < listDataSize; ++i )
+		//		{
+		//			ByteUtils.putByte( bb.get(), listData.data, i );
+		//		}
+		//		return new VolatileLabelMultisetArray( data, listData, true, argMax );
+		@Override
+		public byte[] apply( final CellGrid cellGrid, final long[] cellPos )
+		{
+			final long[] cellMin = new long[ cellPos.length ];
+			final int[] cellDims = new int[ cellMin.length ];
+			Arrays.setAll(cellMin, d-> cellPos[ d ] * cellGrid.cellDimension( d ) );
+			cellGrid.getCellDimensions( cellPos, cellMin, cellDims );
+			final int numElements = numElements( cellDims );
+
+			final LongMappedAccessData listData = LongMappedAccessData.factory.createStorage( 0 );
+			final LabelMultisetEntryList list = new LabelMultisetEntryList( listData, 0 );
+			final LabelMultisetEntry entry = new LabelMultisetEntry( 0, 1 );
+			list.createListAt( listData, 0 );
+			entry.setId( id );
+			entry.setCount( 1 );
+			list.add( entry );
+			final int listSize = ( int ) list.getSizeInBytes();
+
+			final byte[] bytes = new byte[ Integer.BYTES
+					+ numElements * Long.BYTES // for argmaxes
+					+ numElements * Integer.BYTES // for mappings
+					+ listSize // for actual entries (one single entry)
+					];
+
+			final ByteBuffer bb = ByteBuffer.wrap(bytes);
+
+			// argmax
+			bb.putInt( numElements );
+			for ( int i = 0; i < numElements; ++i )
+				bb.putLong( id );
+
+			// offsets
+			for ( int i = 0; i < numElements; ++i )
+				bb.putInt( 0 );
+
+
+
+//			bb.putInt( 1 );
+			LOG.debug("Putting id {}", id);
+			for ( int i = 0; i < listSize; ++i )
+			{
+				//ByteUtils.putByte( bb.get(), listData.data, i );
+				bb.put( ByteUtils.getByte( listData.getData(), i ) );
+			}
+//			bb.putLong( id );
+//			bb.putInt( 1 );
+
+			LOG.debug("Returning {} bytes for {} elements", bytes.length, numElements);
+
+			return bytes;
+		}
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisets.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisets.java
@@ -115,6 +115,9 @@ public class N5LabelMultisets {
 			final BiFunction<CellGrid, long[], byte[]> nullReplacement,
 			final LoaderCache<Long, Cell<VolatileLabelMultisetArray>> loaderCache) throws IOException {
 
+		if (!isLabelMultisetType(n5, dataset))
+			throw new IOException(dataset + " is not a label multiset dataset.");
+
 		final DatasetAttributes attributes = n5.getDatasetAttributes(dataset);
 		final CellGrid grid = new CellGrid(attributes.getDimensions(), attributes.getBlockSize());
 
@@ -277,6 +280,9 @@ public class N5LabelMultisets {
 			final DatasetAttributes attributes,
 			final long[] gridOffset) throws IOException {
 
+		if (!isLabelMultisetType(n5, dataset))
+			throw new IOException(dataset + " is not a label multiset dataset.");
+
 		source = Views.zeroMin(source);
 		final long[] dimensions = Intervals.dimensionsAsLongArray(source);
 
@@ -352,6 +358,9 @@ public class N5LabelMultisets {
 			final String dataset,
 			final long[] gridOffset,
 			final ExecutorService exec) throws IOException, InterruptedException, ExecutionException {
+
+		if (!isLabelMultisetType(n5, dataset))
+			throw new IOException(dataset + " is not a label multiset dataset.");
 
 		final RandomAccessibleInterval<LabelMultisetType> zeroMinSource = Views.zeroMin(source);
 		final long[] dimensions = Intervals.dimensionsAsLongArray(zeroMinSource);
@@ -431,6 +440,9 @@ public class N5LabelMultisets {
 			final DatasetAttributes attributes,
 			final long[] gridOffset,
 			final long defaultLabelId) throws IOException {
+
+		if (!isLabelMultisetType(n5, dataset))
+			throw new IOException(dataset + " is not a label multiset dataset.");
 
 		source = Views.zeroMin(source);
 		final long[] dimensions = Intervals.dimensionsAsLongArray(source);

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisets.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisets.java
@@ -1,0 +1,119 @@
+package org.janelia.saalfeldlab.n5.imglib2;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.N5Reader;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.cache.LoaderCache;
+import net.imglib2.cache.img.CachedCellImg;
+import net.imglib2.cache.ref.SoftRefLoaderCache;
+import net.imglib2.cache.util.LoaderCacheAsCacheAdapter;
+import net.imglib2.img.cell.Cell;
+import net.imglib2.img.cell.CellGrid;
+import net.imglib2.img.cell.LazyCellImg;
+import net.imglib2.type.label.Label;
+import net.imglib2.type.label.LabelMultisetType;
+import net.imglib2.type.label.VolatileLabelMultisetArray;
+
+public class N5LabelMultisets {
+
+	public static final String LABEL_MULTISETTYPE_KEY = "isLabelMultiset";
+
+	/**
+	 * Determine whether an N5 dataset is of type {@link LabelMultisetType}.
+	 *
+	 * @param n5
+	 * @param dataset
+	 * @return
+	 */
+	public static boolean isLabelMultisetType(final N5Reader n5, final String dataset) throws IOException {
+
+		return Optional
+				.ofNullable(n5.getAttribute(dataset, LABEL_MULTISETTYPE_KEY, Boolean.class))
+				.orElse(false);
+	}
+
+	/**
+	 * Open an N5 dataset of {@link LabelMultisetType} as a memory cached {@link LazyCellImg}.
+	 *
+	 * @param n5
+	 * @param dataset
+	 * @return
+	 * @throws IOException
+	 */
+	public static final RandomAccessibleInterval<LabelMultisetType> openLabelMultiset(
+			final N5Reader n5,
+			final String dataset) throws IOException {
+
+		return openLabelMultiset(n5, dataset, Label.BACKGROUND);
+	}
+
+	/**
+	 * Open an N5 dataset of {@link LabelMultisetType} as a memory cached {@link LazyCellImg}.
+	 *
+	 * @param n5
+	 * @param dataset
+	 * @param defaultLabelId
+	 * @return
+	 * @throws IOException
+	 */
+	public static final RandomAccessibleInterval<LabelMultisetType> openLabelMultiset(
+			final N5Reader n5,
+			final String dataset,
+			final long defaultLabelId) throws IOException {
+
+		return openLabelMultiset(n5, dataset, N5LabelMultisetCacheLoader.constantNullReplacement(defaultLabelId));
+	}
+
+	/**
+	 * Open an N5 dataset of {@link LabelMultisetType} as a memory cached {@link LazyCellImg}.
+	 *
+	 * @param n5
+	 * @param dataset
+	 * @param nullReplacement
+	 * @return
+	 * @throws IOException
+	 */
+	public static final RandomAccessibleInterval<LabelMultisetType> openLabelMultiset(
+			final N5Reader n5,
+			final String dataset,
+			final BiFunction<CellGrid, long[], byte[]> nullReplacement) throws IOException {
+
+		return openLabelMultiset(n5, dataset, nullReplacement, new SoftRefLoaderCache<>());
+	}
+
+	/**
+	 * Open an N5 dataset of {@link LabelMultisetType} as a memory cached {@link LazyCellImg}.
+	 *
+	 * @param n5
+	 * @param dataset
+	 * @param nullReplacement
+	 * @param loaderCache
+	 * @return
+	 * @throws IOException
+	 */
+	public static final CachedCellImg<LabelMultisetType, VolatileLabelMultisetArray> openLabelMultiset(
+			final N5Reader n5,
+			final String dataset,
+			final BiFunction<CellGrid, long[], byte[]> nullReplacement,
+			final LoaderCache<Long, Cell<VolatileLabelMultisetArray>> loaderCache) throws IOException {
+
+		final DatasetAttributes attributes = n5.getDatasetAttributes(dataset);
+		final CellGrid grid = new CellGrid(attributes.getDimensions(), attributes.getBlockSize());
+
+		final N5LabelMultisetCacheLoader loader = new N5LabelMultisetCacheLoader(n5, dataset, nullReplacement);
+		final LoaderCacheAsCacheAdapter<Long, Cell<VolatileLabelMultisetArray>> wrappedCache = new LoaderCacheAsCacheAdapter<>(loaderCache, loader);
+
+		final CachedCellImg<LabelMultisetType, VolatileLabelMultisetArray> cachedImg = new CachedCellImg<>(
+				grid,
+				new LabelMultisetType().getEntitiesPerPixel(),
+				wrappedCache,
+				new VolatileLabelMultisetArray(0, true, new long[] {Label.INVALID}));
+		cachedImg.setLinkedType(new LabelMultisetType(cachedImg));
+		return cachedImg;
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisets.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisets.java
@@ -1,11 +1,20 @@
 package org.janelia.saalfeldlab.n5.imglib2;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.function.BiFunction;
 
+import org.janelia.saalfeldlab.n5.ByteArrayDataBlock;
+import org.janelia.saalfeldlab.n5.Compression;
+import org.janelia.saalfeldlab.n5.DataBlock;
+import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.N5Writer;
 
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.cache.LoaderCache;
@@ -17,7 +26,11 @@ import net.imglib2.img.cell.CellGrid;
 import net.imglib2.img.cell.LazyCellImg;
 import net.imglib2.type.label.Label;
 import net.imglib2.type.label.LabelMultisetType;
+import net.imglib2.type.label.LabelMultisetType.Entry;
+import net.imglib2.type.label.LabelUtils;
 import net.imglib2.type.label.VolatileLabelMultisetArray;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
 
 public class N5LabelMultisets {
 
@@ -115,5 +128,440 @@ public class N5LabelMultisets {
 				new VolatileLabelMultisetArray(0, true, new long[] {Label.INVALID}));
 		cachedImg.setLinkedType(new LabelMultisetType(cachedImg));
 		return cachedImg;
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} of type {@link LabelMultisetType} as an N5 dataset.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @param blockSize
+	 * @param compression
+	 * @throws IOException
+	 */
+	public static final void saveLabelMultiset(
+			RandomAccessibleInterval<LabelMultisetType> source,
+			final N5Writer n5,
+			final String dataset,
+			final int[] blockSize,
+			final Compression compression) throws IOException {
+
+		source = Views.zeroMin(source);
+		final long[] dimensions = Intervals.dimensionsAsLongArray(source);
+		final DatasetAttributes attributes = new DatasetAttributes(
+				dimensions,
+				blockSize,
+				DataType.UINT8,
+				compression);
+
+		n5.createDataset(dataset, attributes);
+		n5.setAttribute(dataset, LABEL_MULTISETTYPE_KEY, true);
+
+		final int n = dimensions.length;
+		final long[] max = Intervals.maxAsLongArray(source);
+		final long[] offset = new long[n];
+		final long[] gridPosition = new long[n];
+		final int[] intCroppedBlockSize = new int[n];
+		final long[] longCroppedBlockSize = new long[n];
+		for (int d = 0; d < n;) {
+			N5Utils.cropBlockDimensions(max, offset, blockSize, longCroppedBlockSize, intCroppedBlockSize, gridPosition);
+			final RandomAccessibleInterval<LabelMultisetType> sourceBlock = Views.offsetInterval(source, offset, longCroppedBlockSize);
+			final ByteArrayDataBlock dataBlock = createDataBlock(sourceBlock, gridPosition);
+
+			n5.writeBlock(dataset, attributes, dataBlock);
+
+			for (d = 0; d < n; ++d) {
+				offset[d] += blockSize[d];
+				if (offset[d] <= max[d])
+					break;
+				else
+					offset[d] = 0;
+			}
+		}
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} of type {@link LabelMultisetType} as an N5 dataset, multi-threaded.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @param blockSize
+	 * @param compression
+	 * @param exec
+	 * @throws IOException
+	 * @throws InterruptedException
+	 * @throws ExecutionException
+	 */
+	public static final void saveLabelMultiset(
+			final RandomAccessibleInterval<LabelMultisetType> source,
+			final N5Writer n5,
+			final String dataset,
+			final int[] blockSize,
+			final Compression compression,
+			final ExecutorService exec) throws IOException, InterruptedException, ExecutionException {
+
+		final RandomAccessibleInterval<LabelMultisetType> zeroMinSource = Views.zeroMin(source);
+		final long[] dimensions = Intervals.dimensionsAsLongArray(zeroMinSource);
+		final DatasetAttributes attributes = new DatasetAttributes(
+				dimensions,
+				blockSize,
+				DataType.UINT8,
+				compression);
+
+		n5.createDataset(dataset, attributes);
+		n5.setAttribute(dataset, LABEL_MULTISETTYPE_KEY, true);
+
+		final int n = dimensions.length;
+		final long[] max = Intervals.maxAsLongArray(zeroMinSource);
+		final long[] offset = new long[n];
+
+		final ArrayList<Future<?>> futures = new ArrayList<>();
+		for (int d = 0; d < n;) {
+			final long[] fOffset = offset.clone();
+
+			futures.add(
+					exec.submit(
+							() -> {
+
+								final long[] gridPosition = new long[n];
+								final int[] intCroppedBlockSize = new int[n];
+								final long[] longCroppedBlockSize = new long[n];
+
+								N5Utils.cropBlockDimensions(
+										max,
+										fOffset,
+										blockSize,
+										longCroppedBlockSize,
+										intCroppedBlockSize,
+										gridPosition);
+
+								final RandomAccessibleInterval<LabelMultisetType> sourceBlock = Views
+										.offsetInterval(zeroMinSource, fOffset, longCroppedBlockSize);
+								final ByteArrayDataBlock dataBlock = createDataBlock(sourceBlock, gridPosition);
+
+								try {
+									n5.writeBlock(dataset, attributes, dataBlock);
+								} catch (final IOException e) {
+									e.printStackTrace();
+								}
+							}));
+
+			for (d = 0; d < n; ++d) {
+				offset[d] += blockSize[d];
+				if (offset[d] <= max[d])
+					break;
+				else
+					offset[d] = 0;
+			}
+		}
+		for (final Future<?> f : futures)
+			f.get();
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} of type {@link LabelMultisetType} into an existing N5 dataset.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @param attributes
+	 * @param gridOffset
+	 * @throws IOException
+	 */
+	public static final void saveLabelMultisetBlock(
+			RandomAccessibleInterval<LabelMultisetType> source,
+			final N5Writer n5,
+			final String dataset,
+			final DatasetAttributes attributes,
+			final long[] gridOffset) throws IOException {
+
+		source = Views.zeroMin(source);
+		final long[] dimensions = Intervals.dimensionsAsLongArray(source);
+
+		final int n = dimensions.length;
+		final long[] max = Intervals.maxAsLongArray(source);
+		final long[] offset = new long[n];
+		final long[] gridPosition = new long[n];
+		final int[] blockSize = attributes.getBlockSize();
+		final int[] intCroppedBlockSize = new int[n];
+		final long[] longCroppedBlockSize = new long[n];
+		for (int d = 0; d < n;) {
+			N5Utils.cropBlockDimensions(
+					max,
+					offset,
+					gridOffset,
+					blockSize,
+					longCroppedBlockSize,
+					intCroppedBlockSize,
+					gridPosition);
+			final RandomAccessibleInterval<LabelMultisetType> sourceBlock = Views.offsetInterval(source, offset, longCroppedBlockSize);
+			final ByteArrayDataBlock dataBlock = createDataBlock(sourceBlock, gridPosition);
+
+			n5.writeBlock(dataset, attributes, dataBlock);
+
+			for (d = 0; d < n; ++d) {
+				offset[d] += blockSize[d];
+				if (offset[d] <= max[d])
+					break;
+				else
+					offset[d] = 0;
+			}
+		}
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} of type {@link LabelMultisetType} into an existing N5 dataset.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @param gridOffset
+	 * @throws IOException
+	 */
+	public static final void saveLabelMultisetBlock(
+			final RandomAccessibleInterval<LabelMultisetType> source,
+			final N5Writer n5,
+			final String dataset,
+			final long[] gridOffset) throws IOException {
+
+		final DatasetAttributes attributes = n5.getDatasetAttributes(dataset);
+		if (attributes != null) {
+			saveLabelMultisetBlock(source, n5, dataset, attributes, gridOffset);
+		} else {
+			throw new IOException("Dataset " + dataset + " does not exist.");
+		}
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} of type {@link LabelMultisetType} into an existing N5 dataset, multi-threaded.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @param gridOffset
+	 * @param exec
+	 * @throws IOException
+	 * @throws InterruptedException
+	 * @throws ExecutionException
+	 */
+	public static final void saveLabelMultisetBlock(
+			final RandomAccessibleInterval<LabelMultisetType> source,
+			final N5Writer n5,
+			final String dataset,
+			final long[] gridOffset,
+			final ExecutorService exec) throws IOException, InterruptedException, ExecutionException {
+
+		final RandomAccessibleInterval<LabelMultisetType> zeroMinSource = Views.zeroMin(source);
+		final long[] dimensions = Intervals.dimensionsAsLongArray(zeroMinSource);
+		final DatasetAttributes attributes = n5.getDatasetAttributes(dataset);
+		if (attributes != null) {
+			final int n = dimensions.length;
+			final long[] max = Intervals.maxAsLongArray(zeroMinSource);
+			final long[] offset = new long[n];
+			final int[] blockSize = attributes.getBlockSize();
+
+			final ArrayList<Future<?>> futures = new ArrayList<>();
+			for (int d = 0; d < n;) {
+				final long[] fOffset = offset.clone();
+
+				futures.add(
+						exec.submit(
+								() -> {
+
+									final long[] gridPosition = new long[n];
+									final int[] intCroppedBlockSize = new int[n];
+									final long[] longCroppedBlockSize = new long[n];
+
+									N5Utils.cropBlockDimensions(
+											max,
+											fOffset,
+											gridOffset,
+											blockSize,
+											longCroppedBlockSize,
+											intCroppedBlockSize,
+											gridPosition);
+
+									final RandomAccessibleInterval<LabelMultisetType> sourceBlock = Views
+											.offsetInterval(zeroMinSource, fOffset, longCroppedBlockSize);
+									final ByteArrayDataBlock dataBlock = createDataBlock(sourceBlock, gridPosition);
+
+									try {
+										n5.writeBlock(dataset, attributes, dataBlock);
+									} catch (final IOException e) {
+										e.printStackTrace();
+									}
+								}));
+
+				for (d = 0; d < n; ++d) {
+					offset[d] += blockSize[d];
+					if (offset[d] <= max[d])
+						break;
+					else
+						offset[d] = 0;
+				}
+			}
+			for (final Future<?> f : futures)
+				f.get();
+		} else {
+			throw new IOException("Dataset " + dataset + " does not exist.");
+		}
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} of type {@link LabelMultisetType} into an N5 dataset at a given
+	 * offset. The offset is given in {@link DataBlock} grid coordinates and the
+	 * source is assumed to align with the {@link DataBlock} grid of the
+	 * dataset. Only {@link DataBlock DataBlocks} that contain labels other than
+	 * a given default label are stored.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @param attributes
+	 * @param gridOffset
+	 * @param defaultLabelId
+	 * @throws IOException
+	 */
+	public static final void saveLabelMultisetNonEmptyBlock(
+			RandomAccessibleInterval<LabelMultisetType> source,
+			final N5Writer n5,
+			final String dataset,
+			final DatasetAttributes attributes,
+			final long[] gridOffset,
+			final long defaultLabelId) throws IOException {
+
+		source = Views.zeroMin(source);
+		final long[] dimensions = Intervals.dimensionsAsLongArray(source);
+
+		final int n = dimensions.length;
+		final long[] max = Intervals.maxAsLongArray(source);
+		final long[] offset = new long[n];
+		final long[] gridPosition = new long[n];
+		final int[] blockSize = attributes.getBlockSize();
+		final int[] intCroppedBlockSize = new int[n];
+		final long[] longCroppedBlockSize = new long[n];
+		for (int d = 0; d < n;) {
+			N5Utils.cropBlockDimensions(
+					max,
+					offset,
+					gridOffset,
+					blockSize,
+					longCroppedBlockSize,
+					intCroppedBlockSize,
+					gridPosition);
+			final RandomAccessibleInterval<LabelMultisetType> sourceBlock = Views.offsetInterval(source, offset, longCroppedBlockSize);
+			final ByteArrayDataBlock dataBlock = createNonEmptyDataBlock(sourceBlock, gridPosition, defaultLabelId);
+
+			if (dataBlock != null)
+				n5.writeBlock(dataset, attributes, dataBlock);
+
+			for (d = 0; d < n; ++d) {
+				offset[d] += blockSize[d];
+				if (offset[d] <= max[d])
+					break;
+				else
+					offset[d] = 0;
+			}
+		}
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} of type {@link LabelMultisetType} into an N5 dataset at a given
+	 * offset. The offset is given in {@link DataBlock} grid coordinates and the
+	 * source is assumed to align with the {@link DataBlock} grid of the
+	 * dataset. Only {@link DataBlock DataBlocks} that contain labels other than
+	 * a given default label are stored.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @param gridOffset
+	 * @param defaultLabelId
+	 * @throws IOException
+	 */
+	public static final void saveLabelMultisetNonEmptyBlock(
+			final RandomAccessibleInterval<LabelMultisetType> source,
+			final N5Writer n5,
+			final String dataset,
+			final long[] gridOffset,
+			final long defaultLabelId) throws IOException {
+
+		final DatasetAttributes attributes = n5.getDatasetAttributes(dataset);
+		if (attributes != null) {
+			saveLabelMultisetNonEmptyBlock(source, n5, dataset, attributes, gridOffset, defaultLabelId);
+		} else {
+			throw new IOException("Dataset " + dataset + " does not exist.");
+		}
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} of type {@link LabelMultisetType} into an N5 dataset at a given
+	 * offset. The offset is given in {@link DataBlock} grid coordinates and the
+	 * source is assumed to align with the {@link DataBlock} grid of the
+	 * dataset. Only {@link DataBlock DataBlocks} that contain labels other than
+	 * {@link Label#BACKGROUND} are stored.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @param gridOffset
+	 * @throws IOException
+	 */
+	public static final void saveLabelMultisetNonEmptyBlock(
+			final RandomAccessibleInterval<LabelMultisetType> source,
+			final N5Writer n5,
+			final String dataset,
+			final long[] gridOffset) throws IOException {
+
+		saveLabelMultisetNonEmptyBlock(source, n5, dataset, gridOffset, Label.BACKGROUND);
+	}
+
+	/**
+	 * Creates a {@link ByteArrayDataBlock} with serialized source contents of type {@link LabelMultisetType}.
+	 *
+	 * @param source
+	 * @param gridPosition
+	 * @return
+	 */
+	private static final ByteArrayDataBlock createDataBlock(
+			final RandomAccessibleInterval<LabelMultisetType> source,
+			final long[] gridPosition) {
+
+		final byte[] data = LabelUtils.serializeLabelMultisetTypes(
+				Views.flatIterable(source),
+				(int) Intervals.numElements(source)
+			);
+
+		final ByteArrayDataBlock dataBlock = new ByteArrayDataBlock(
+				Intervals.dimensionsAsIntArray(source),
+				gridPosition,
+				data
+			);
+
+		return dataBlock;
+	}
+
+	/**
+	 * Creates a {@link ByteArrayDataBlock} with serialized source contents of type {@link LabelMultisetType},
+	 * or returns {@code null} if all labels are equal to {@code defaultLabelId} (regardless of their counts).
+	 *
+	 * @param source
+	 * @param gridPosition
+	 * @param defaultLabelId
+	 * @return
+	 */
+	private static final ByteArrayDataBlock createNonEmptyDataBlock(
+			final RandomAccessibleInterval<LabelMultisetType> source,
+			final long[] gridPosition,
+			final long defaultLabelId) {
+
+		boolean isEmpty = true;
+		for (final LabelMultisetType lmt : Views.iterable(source))
+			for (final Entry<Label> entry : lmt.entrySet())
+				isEmpty &= entry.getElement().id() == defaultLabelId;
+
+		return isEmpty ? null : createDataBlock(source, gridPosition);
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
@@ -64,6 +64,7 @@ import net.imglib2.img.cell.CellGrid;
 import net.imglib2.img.cell.LazyCellImg;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.Type;
+import net.imglib2.type.label.LabelMultisetType;
 import net.imglib2.type.numeric.integer.ByteType;
 import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.integer.LongType;
@@ -378,17 +379,22 @@ public class N5Utils {
 
 	/**
 	 * Open an N5 dataset as a memory cached {@link LazyCellImg}.
+	 * Supports all primitive types and {@link LabelMultisetType}.
 	 *
 	 * @param n5
 	 * @param dataset
 	 * @return
 	 * @throws IOException
 	 */
+	@SuppressWarnings("unchecked")
 	public static final <T extends NativeType<T>> RandomAccessibleInterval<T> open(
 			final N5Reader n5,
 			final String dataset) throws IOException {
 
-		return open(n5, dataset, (Consumer<IterableInterval<T>>)img -> {});
+		if (N5LabelMultisets.isLabelMultisetType(n5, dataset))
+			return (RandomAccessibleInterval<T>) N5LabelMultisets.openLabelMultiset(n5, dataset);
+		else
+			return open(n5, dataset, (Consumer<IterableInterval<T>>)img -> {});
 	}
 
 
@@ -412,17 +418,22 @@ public class N5Utils {
 	/**
 	 * Open an N5 dataset as a memory cached {@link LazyCellImg} using
 	 * {@link VolatileAccess}.
+	 * Supports all primitive types and {@link LabelMultisetType}.
 	 *
 	 * @param n5
 	 * @param dataset
 	 * @return
 	 * @throws IOException
 	 */
+	@SuppressWarnings("unchecked")
 	public static final <T extends NativeType<T>> RandomAccessibleInterval<T> openVolatile(
 			final N5Reader n5,
 			final String dataset) throws IOException {
 
-		return openVolatile(n5, dataset, (Consumer<IterableInterval<T>>)img -> {});
+		if (N5LabelMultisets.isLabelMultisetType(n5, dataset))
+			return (RandomAccessibleInterval<T>) N5LabelMultisets.openLabelMultiset(n5, dataset);
+		else
+			return openVolatile(n5, dataset, (Consumer<IterableInterval<T>>)img -> {});
 	}
 
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
@@ -885,6 +885,13 @@ public class N5Utils {
 			final DatasetAttributes attributes,
 			final long[] gridOffset) throws IOException {
 
+		if (N5LabelMultisets.isLabelMultisetType(n5, dataset)) {
+			@SuppressWarnings("unchecked")
+			final RandomAccessibleInterval<LabelMultisetType> labelMultisetSource = (RandomAccessibleInterval<LabelMultisetType>) source;
+			N5LabelMultisets.saveLabelMultisetBlock(labelMultisetSource, n5, dataset, attributes, gridOffset);
+			return;
+		}
+
 		source = Views.zeroMin(source);
 		final long[] dimensions = Intervals.dimensionsAsLongArray(source);
 
@@ -965,6 +972,13 @@ public class N5Utils {
 			final String dataset,
 			final long[] gridOffset,
 			final ExecutorService exec) throws IOException, InterruptedException, ExecutionException {
+
+		if (N5LabelMultisets.isLabelMultisetType(n5, dataset)) {
+			@SuppressWarnings("unchecked")
+			final RandomAccessibleInterval<LabelMultisetType> labelMultisetSource = (RandomAccessibleInterval<LabelMultisetType>) source;
+			N5LabelMultisets.saveLabelMultisetBlock(labelMultisetSource, n5, dataset, gridOffset, exec);
+			return;
+		}
 
 		final RandomAccessibleInterval<T> zeroMinSource = Views.zeroMin(source);
 		final long[] dimensions = Intervals.dimensionsAsLongArray(zeroMinSource);
@@ -1137,6 +1151,13 @@ public class N5Utils {
 			final int[] blockSize,
 			final Compression compression) throws IOException {
 
+		if (Util.getTypeFromInterval(source) instanceof LabelMultisetType) {
+			@SuppressWarnings("unchecked")
+			final RandomAccessibleInterval<LabelMultisetType> labelMultisetSource = (RandomAccessibleInterval<LabelMultisetType>) source;
+			N5LabelMultisets.saveLabelMultiset(labelMultisetSource, n5, dataset, blockSize, compression);
+			return;
+		}
+
 		source = Views.zeroMin(source);
 		final long[] dimensions = Intervals.dimensionsAsLongArray(source);
 		final DatasetAttributes attributes = new DatasetAttributes(
@@ -1195,6 +1216,13 @@ public class N5Utils {
 			final int[] blockSize,
 			final Compression compression,
 			final ExecutorService exec) throws IOException, InterruptedException, ExecutionException {
+
+		if (Util.getTypeFromInterval(source) instanceof LabelMultisetType) {
+			@SuppressWarnings("unchecked")
+			final RandomAccessibleInterval<LabelMultisetType> labelMultisetSource = (RandomAccessibleInterval<LabelMultisetType>) source;
+			N5LabelMultisets.saveLabelMultiset(labelMultisetSource, n5, dataset, blockSize, compression, exec);
+			return;
+		}
 
 		final RandomAccessibleInterval<T> zeroMinSource = Views.zeroMin(source);
 		final long[] dimensions = Intervals.dimensionsAsLongArray(zeroMinSource);

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
@@ -331,7 +331,7 @@ public class N5Utils {
 	 * @param intCroppedBlockDimensions
 	 * @param gridPosition
 	 */
-	private static void cropBlockDimensions(
+	static void cropBlockDimensions(
 			final long[] max,
 			final long[] offset,
 			final int[] blockDimensions,
@@ -361,7 +361,7 @@ public class N5Utils {
 	 * @param intCroppedBlockDimensions
 	 * @param gridPosition
 	 */
-	private static void cropBlockDimensions(
+	static void cropBlockDimensions(
 			final long[] max,
 			final long[] offset,
 			final long[] gridOffset,


### PR DESCRIPTION
This PR adds support for opening and saving label multiset data from/to N5.

The new class `N5LabelMultisets` provides methods that are specific to label multisets. Additionally, the basic versions of the open/save methods in `N5Utils` can detect whether the requested dataset contains label multiset data and redirect to the appropriate methods.

N5 cache loader for `LabelMultisetType` was moved from another repository, see [n5-label-multisets#7](https://github.com/saalfeldlab/n5-label-multisets/pull/7).
The modified version in the above PR was added as a snapshot dependency, and will be changed to the release version once that PR is merged.