### PR TITLE
Test label multisets functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-label-multisets</artifactId>
-			<version>0.5.1-SNAPSHOT</version>
+			<version>0.6.0</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-label-multisets</artifactId>
-			<version>0.5.0</version>
+			<version>0.5.1-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisets.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisets.java
@@ -2,6 +2,7 @@ package org.janelia.saalfeldlab.n5.imglib2;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -319,6 +320,54 @@ public class N5LabelMultisets {
 
 	/**
 	 * Save a {@link RandomAccessibleInterval} of type {@link LabelMultisetType} into an existing N5 dataset.
+	 * The block offset is determined by the source position, and the
+	 * source is assumed to align with the {@link DataBlock} grid
+	 * of the dataset.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @param attributes
+	 * @throws IOException
+	 */
+	public static final void saveLabelMultisetBlock(
+			final RandomAccessibleInterval<LabelMultisetType> source,
+			final N5Writer n5,
+			final String dataset,
+			final DatasetAttributes attributes) throws IOException {
+
+		final int[] blockSize = attributes.getBlockSize();
+		final long[] gridOffset = new long[blockSize.length];
+		Arrays.setAll(gridOffset, d -> source.min(d) / blockSize[d]);
+		saveLabelMultisetBlock(source, n5, dataset, attributes, gridOffset);
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} of type {@link LabelMultisetType} into an existing N5 dataset.
+	 * The block offset is determined by the source position, and the
+	 * source is assumed to align with the {@link DataBlock} grid
+	 * of the dataset.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @throws IOException
+	 */
+	public static final void saveLabelMultisetBlock(
+			final RandomAccessibleInterval<LabelMultisetType> source,
+			final N5Writer n5,
+			final String dataset) throws IOException {
+
+		final DatasetAttributes attributes = n5.getDatasetAttributes(dataset);
+		if (attributes != null) {
+			saveLabelMultisetBlock(source, n5, dataset, attributes);
+		} else {
+			throw new IOException("Dataset " + dataset + " does not exist.");
+		}
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} of type {@link LabelMultisetType} into an existing N5 dataset.
 	 *
 	 * @param source
 	 * @param n5
@@ -477,6 +526,83 @@ public class N5LabelMultisets {
 					offset[d] = 0;
 			}
 		}
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} of type {@link LabelMultisetType} into an N5 dataset.
+	 * The block offset is determined by the source position, and the
+	 * source is assumed to align with the {@link DataBlock} grid
+	 * of the dataset.
+	 * Only {@link DataBlock DataBlocks} that contain labels other than
+	 * a given default label are stored.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @param attributes
+	 * @param defaultLabelId
+	 * @throws IOException
+	 */
+	public static final void saveLabelMultisetNonEmptyBlock(
+			final RandomAccessibleInterval<LabelMultisetType> source,
+			final N5Writer n5,
+			final String dataset,
+			final DatasetAttributes attributes,
+			final long defaultLabelId) throws IOException {
+
+		final int[] blockSize = attributes.getBlockSize();
+		final long[] gridOffset = new long[blockSize.length];
+		Arrays.setAll(gridOffset, d -> source.min(d) / blockSize[d]);
+		saveLabelMultisetNonEmptyBlock(source, n5, dataset, attributes, gridOffset, defaultLabelId);
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} of type {@link LabelMultisetType} into an N5 dataset.
+	 * The block offset is determined by the source position, and the
+	 * source is assumed to align with the {@link DataBlock} grid
+	 * of the dataset.
+	 * Only {@link DataBlock DataBlocks} that contain labels other than
+	 * a given default label are stored.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @param defaultLabelId
+	 * @throws IOException
+	 */
+	public static final void saveLabelMultisetNonEmptyBlock(
+			final RandomAccessibleInterval<LabelMultisetType> source,
+			final N5Writer n5,
+			final String dataset,
+			final long defaultLabelId) throws IOException {
+
+		final DatasetAttributes attributes = n5.getDatasetAttributes(dataset);
+		if (attributes != null) {
+			saveLabelMultisetNonEmptyBlock(source, n5, dataset, attributes, defaultLabelId);
+		} else {
+			throw new IOException("Dataset " + dataset + " does not exist.");
+		}
+	}
+
+	/**
+	 * Save a {@link RandomAccessibleInterval} of type {@link LabelMultisetType} into an N5 dataset.
+	 * The block offset is determined by the source position, and the
+	 * source is assumed to align with the {@link DataBlock} grid
+	 * of the dataset.
+	 * Only {@link DataBlock DataBlocks} that contain labels other than
+	 * {@link Label#BACKGROUND} are stored.
+	 *
+	 * @param source
+	 * @param n5
+	 * @param dataset
+	 * @throws IOException
+	 */
+	public static final void saveLabelMultisetNonEmptyBlock(
+			final RandomAccessibleInterval<LabelMultisetType> source,
+			final N5Writer n5,
+			final String dataset) throws IOException {
+
+		saveLabelMultisetNonEmptyBlock(source, n5, dataset, Label.BACKGROUND);
 	}
 
 	/**

--- a/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisetsTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisetsTest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2017-2018, Stephan Saalfeld, Philipp Hanslovsky, Igor Pisarev
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.janelia.saalfeldlab.n5.imglib2;
+
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.janelia.saalfeldlab.n5.GzipCompression;
+import org.janelia.saalfeldlab.n5.N5FSWriter;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.RawCompression;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.list.ListImg;
+import net.imglib2.type.label.Label;
+import net.imglib2.type.label.LabelMultisetEntry;
+import net.imglib2.type.label.LabelMultisetEntryList;
+import net.imglib2.type.label.LabelMultisetType;
+import net.imglib2.type.label.LabelMultisetType.Entry;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+
+public class N5LabelMultisetsTest {
+
+	static private String testDirPath = System.getProperty("user.home") + "/tmp/n5-imglib2-test";
+
+	static private String datasetName = "/test/group/dataset/label";
+
+	static private long[] dimensions = new long[]{11, 22, 33};
+
+	static private int[] blockSize = new int[]{5, 7, 9};
+
+	static private RandomAccessibleInterval<LabelMultisetType> expectedImg;
+
+	static private N5Writer n5;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+
+		final File testDir = new File(testDirPath);
+		testDir.mkdirs();
+		if (!(testDir.exists() && testDir.isDirectory()))
+			throw new IOException("Could not create test directory for HDF5Utils test.");
+
+		n5 = new N5FSWriter(testDirPath);
+
+		final Random rnd = new Random();
+
+		final int numElements = (int) Intervals.numElements(dimensions);
+		final List<LabelMultisetType> typeElements = new ArrayList<>();
+		for (int i = 0; i < numElements; ++i)
+		{
+			final int numEntries = rnd.nextInt(10);
+			final LabelMultisetEntryList entries = new LabelMultisetEntryList(numEntries);
+			for (int j = 0; j < numEntries; ++j)
+				entries.add(new LabelMultisetEntry(rnd.nextInt(10000), rnd.nextInt(100)));
+			typeElements.add(new LabelMultisetType(entries));
+		}
+		expectedImg = new ListImg<>(typeElements, dimensions);
+	}
+
+	@AfterClass
+	public static void rampDownAfterClass() throws Exception {
+
+		n5.remove("");
+	}
+
+	@Test
+	public void testSaveAndOpen() throws InterruptedException, ExecutionException {
+
+		try {
+			N5LabelMultisets.saveLabelMultiset(expectedImg, n5, datasetName, blockSize, new GzipCompression());
+			RandomAccessibleInterval<LabelMultisetType> loaded = N5LabelMultisets.openLabelMultiset(n5, datasetName);
+			assertEquals(loaded);
+
+			ExecutorService exec = Executors.newFixedThreadPool(4);
+			N5LabelMultisets.saveLabelMultiset(expectedImg, n5, datasetName, blockSize, new GzipCompression(), exec);
+			loaded = N5LabelMultisets.openLabelMultiset(n5, datasetName);
+			assertEquals(loaded);
+			exec.shutdown();
+
+			exec = Executors.newFixedThreadPool(8);
+			N5LabelMultisets.saveLabelMultiset(loaded, n5, datasetName, blockSize, new RawCompression(), exec);
+			loaded = N5LabelMultisets.openLabelMultiset(n5, datasetName);
+			assertEquals(loaded);
+			exec.shutdown();
+
+		} catch (final IOException e) {
+			fail("Failed by I/O exception.");
+			e.printStackTrace();
+		}
+	}
+
+	private void assertEquals(final RandomAccessibleInterval<LabelMultisetType> actualImg) {
+
+		Assert.assertTrue(Intervals.equals(expectedImg, actualImg));
+		final Iterator<LabelMultisetType> expectedImgIterator = Views.flatIterable(expectedImg).iterator();
+		final Iterator<LabelMultisetType> actualImgIterator = Views.flatIterable(actualImg).iterator();
+		while (expectedImgIterator.hasNext() || actualImgIterator.hasNext()) {
+			final LabelMultisetType expected = expectedImgIterator.next();
+			final LabelMultisetType actual = actualImgIterator.next();
+			Assert.assertEquals(expected.argMax(), actual.argMax());
+			Assert.assertEquals(expected.size(), actual.size());
+			Assert.assertEquals(expected.entrySet().size(), actual.entrySet().size());
+			final Iterator<Entry<Label>> expectedEntriesIterator = expected.entrySet().iterator();
+			final Iterator<Entry<Label>> actualEntriesIterator = actual.entrySet().iterator();
+			while (expectedEntriesIterator.hasNext() || actualEntriesIterator.hasNext()) {
+				final Entry<Label> expectedEntry = expectedEntriesIterator.next();
+				final Entry<Label> actualEntry = actualEntriesIterator.next();
+				Assert.assertEquals(expectedEntry.getElement().id(), actualEntry.getElement().id());
+				Assert.assertEquals(expectedEntry.getCount(), actualEntry.getCount());
+			}
+		}
+	}
+}

--- a/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisetsTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisetsTest.java
@@ -99,7 +99,7 @@ public class N5LabelMultisetsTest {
 	@AfterClass
 	public static void rampDownAfterClass() throws Exception {
 
-		n5.remove("");
+		Assert.assertTrue(n5.remove(""));
 	}
 
 	@Test
@@ -111,14 +111,15 @@ public class N5LabelMultisetsTest {
 			assertEquals(loaded);
 
 			ExecutorService exec = Executors.newFixedThreadPool(4);
-			N5LabelMultisets.saveLabelMultiset(expectedImg, n5, datasetName, blockSize, new GzipCompression(), exec);
-			loaded = N5LabelMultisets.openLabelMultiset(n5, datasetName);
+			N5LabelMultisets.saveLabelMultiset(expectedImg, n5, datasetName + "-1", blockSize, new GzipCompression(), exec);
+			loaded = N5LabelMultisets.openLabelMultiset(n5, datasetName + "-1");
 			assertEquals(loaded);
 			exec.shutdown();
 
 			exec = Executors.newFixedThreadPool(8);
-			N5LabelMultisets.saveLabelMultiset(loaded, n5, datasetName, blockSize, new RawCompression(), exec);
-			loaded = N5LabelMultisets.openLabelMultiset(n5, datasetName);
+			final int[] differentBlockSize = {6, 10, 3};
+			N5LabelMultisets.saveLabelMultiset(loaded, n5, datasetName + "-2", differentBlockSize, new RawCompression(), exec);
+			loaded = N5LabelMultisets.openLabelMultiset(n5, datasetName + "-2");
 			assertEquals(loaded);
 			exec.shutdown();
 


### PR DESCRIPTION
With simplified initialization, it's now easy to add tests for label multiset open/save functionality.
The test ensures that everything works properly in single- and multi-threaded enviroments.