### PR TITLE
Add method for deleting blocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>27.0.1</version>
 		<relativePath />
 	</parent>
 
@@ -132,7 +132,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5</artifactId>
-			<version>2.1.0</version>
+			<version>2.2.0</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
 	<groupId>org.janelia.saalfeldlab</groupId>
 	<artifactId>n5-imglib2</artifactId>
-	<version>3.4.2-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 
 	<name>N5 ImgLib2 Bindings</name>
 	<description>Open N5 datasets as ImgLib2 RandomAccessibles, and write ImgLib2 RandomAccessibles as/ into N5 datasets.</description>

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
@@ -37,6 +37,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 
+import net.imglib2.FinalInterval;
 import org.janelia.saalfeldlab.n5.Compression;
 import org.janelia.saalfeldlab.n5.DataBlock;
 import org.janelia.saalfeldlab.n5.DataType;
@@ -1387,5 +1388,127 @@ public class N5Utils {
 		}
 		for (final Future<?> f : futures)
 			f.get();
+	}
+
+	/**
+	 * Delete an {@link Interval} in an N5 dataset at a given
+	 * offset. The offset is given in {@link DataBlock} grid coordinates and the
+	 * interval is assumed to align with the {@link DataBlock} grid of the
+	 * dataset.
+	 *
+	 * @param interval
+	 * @param n5
+	 * @param dataset
+	 * @param attributes
+	 * @param gridOffset
+	 * @throws IOException
+	 */
+	public static final void deleteBlock(
+			final Interval interval,
+			final N5Writer n5,
+			final String dataset,
+			final DatasetAttributes attributes,
+			final long[] gridOffset) throws IOException {
+
+		final Interval zeroMinInterval = new FinalInterval(Intervals.dimensionsAsLongArray(interval));
+		final int n = zeroMinInterval.numDimensions();
+		final long[] max = Intervals.maxAsLongArray( zeroMinInterval );
+		final int[] blockSize = attributes.getBlockSize();
+		final long[] offset = new long[n];
+		final long[] gridPosition = new long[n];
+		final int[] intCroppedBlockSize = new int[n];
+		final long[] longCroppedBlockSize = new long[n];
+		for (int d = 0; d < n;) {
+			cropBlockDimensions(
+					max,
+					offset,
+					gridOffset,
+					blockSize,
+					longCroppedBlockSize,
+					intCroppedBlockSize,
+					gridPosition);
+			n5.deleteBlock(dataset, gridPosition);
+			for (d = 0; d < n; ++d) {
+				offset[d] += blockSize[d];
+				if (offset[d] <= max[d])
+					break;
+				else
+					offset[d] = 0;
+			}
+		}
+	}
+
+	/**
+	 * Delete an {@link Interval} in an N5 dataset.
+	 * The block offset is determined by the interval position, and the
+	 * interval is assumed to align with the {@link DataBlock} grid
+	 * of the dataset.
+	 *
+	 * @param interval
+	 * @param n5
+	 * @param dataset
+	 * @param attributes
+	 * @throws IOException
+	 */
+	public static final void deleteBlock(
+			final Interval interval,
+			final N5Writer n5,
+			final String dataset,
+			final DatasetAttributes attributes) throws IOException {
+
+		final int[] blockSize = attributes.getBlockSize();
+		final long[] gridOffset = new long[blockSize.length];
+		Arrays.setAll(gridOffset, d -> interval.min(d) / blockSize[d]);
+		deleteBlock(interval, n5, dataset, attributes, gridOffset);
+	}
+
+	/**
+	 * Delete an {@link Interval} in an N5 dataset.
+	 * The block offset is determined by the interval position, and the
+	 * interval is assumed to align with the {@link DataBlock} grid
+	 * of the dataset.
+	 *
+	 * @param interval
+	 * @param n5
+	 * @param dataset
+	 * @throws IOException
+	 */
+	public static final void deleteBlock(
+			final Interval interval,
+			final N5Writer n5,
+			final String dataset) throws IOException {
+
+		final DatasetAttributes attributes = n5.getDatasetAttributes(dataset);
+		if (attributes != null) {
+			deleteBlock(interval, n5, dataset, attributes);
+		} else {
+			throw new IOException("Dataset " + dataset + " does not exist.");
+		}
+	}
+
+	/**
+	 * Delete an {@link Interval} in an N5 dataset at a given
+	 * offset. The offset is given in {@link DataBlock} grid coordinates and the
+	 * interval is assumed to align with the {@link DataBlock} grid of the
+	 * dataset.
+	 *
+	 * @param interval
+	 * @param n5
+	 * @param dataset
+	 * @param gridOffset
+	 * @throws IOException
+	 */
+	public static final void deleteBlock(
+			final Interval interval,
+			final N5Writer n5,
+			final String dataset,
+			final long[] gridOffset) throws IOException {
+
+		final DatasetAttributes attributes = n5.getDatasetAttributes(dataset);
+		if (attributes != null) {
+			deleteBlock(interval, n5, dataset, attributes, gridOffset);
+		} else {
+			throw new IOException("Dataset " + dataset + " does not exist.");
+		}
 	}
 }


### PR DESCRIPTION
New convenience method `deleteBlock()` that takes an interval (aligned with the block grid) and deletes all blocks inside this interval in a given dataset.