### PR TITLE
Wrap DataBlock.getData() instead of copying

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5CacheLoader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5CacheLoader.java
@@ -1,0 +1,285 @@
+/**
+ * Copyright (c) 2017-2021, Saalfeld lab, HHMI Janelia
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.janelia.saalfeldlab.n5.imglib2;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import net.imglib2.IterableInterval;
+import net.imglib2.cache.CacheLoader;
+import net.imglib2.cache.img.LoadedCellCacheLoader;
+import net.imglib2.img.basictypeaccess.AccessFlags;
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.img.basictypeaccess.array.DirtyByteArray;
+import net.imglib2.img.basictypeaccess.array.DirtyDoubleArray;
+import net.imglib2.img.basictypeaccess.array.DirtyFloatArray;
+import net.imglib2.img.basictypeaccess.array.DirtyIntArray;
+import net.imglib2.img.basictypeaccess.array.DirtyLongArray;
+import net.imglib2.img.basictypeaccess.array.DirtyShortArray;
+import net.imglib2.img.basictypeaccess.array.DoubleArray;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileByteArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileDoubleArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileFloatArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileIntArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileLongArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.DirtyVolatileShortArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileByteArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileDoubleArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileFloatArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileIntArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileLongArray;
+import net.imglib2.img.basictypeaccess.volatiles.array.VolatileShortArray;
+import net.imglib2.img.cell.Cell;
+import net.imglib2.img.cell.CellGrid;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.PrimitiveType;
+import net.imglib2.util.Cast;
+import net.imglib2.util.Intervals;
+import org.janelia.saalfeldlab.n5.DataBlock;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.N5Reader;
+
+import static net.imglib2.img.basictypeaccess.AccessFlags.DIRTY;
+import static net.imglib2.img.basictypeaccess.AccessFlags.VOLATILE;
+
+/**
+ * A {@link CacheLoader} for N5 dataset blocks. Supports all primitive types.
+ *
+ * @param <T>
+ * 		pixel type
+ * @param <A>
+ * 		access type
+ *
+ * @author Tobias Pietzsch
+ */
+public class N5CacheLoader<T extends NativeType<T>, A extends ArrayDataAccess<A>> implements CacheLoader<Long, Cell<A>> {
+
+	private final N5Reader n5;
+	private final String dataset;
+	private final DatasetAttributes attributes;
+	private final CellGrid grid;
+	private final ArrayDataAccessLoader<?, A> cacheArrayLoader;
+	private final CacheLoader<Long, Cell<A>> missingLoader;
+
+	public N5CacheLoader(
+			final N5Reader n5,
+			final String dataset,
+			final CellGrid grid,
+			final T type,
+			final Set<AccessFlags> accessFlags,
+			final Consumer<IterableInterval<T>> blockNotFoundHandler
+	) throws IOException {
+		this.n5 = n5;
+		this.dataset = dataset;
+		this.grid = grid;
+		attributes = n5.getDatasetAttributes(dataset);
+		cacheArrayLoader = createN5CacheArrayLoader(type, accessFlags);
+		missingLoader = LoadedCellCacheLoader.get(grid, blockNotFoundHandler::accept, type, accessFlags);
+	}
+
+	@Override
+	public Cell<A> get(final Long key) throws Exception {
+		final int n = grid.numDimensions();
+		final long[] cellGridPosition = new long[n];
+		grid.getCellGridPositionFlat(key, cellGridPosition);
+		final DataBlock<?> dataBlock = n5.readBlock(dataset, attributes, cellGridPosition);
+		if ( dataBlock != null ) {
+			final long[] cellMin = new long[n];
+			final int[] cellDims = new int[n];
+			grid.getCellDimensions(key, cellMin, cellDims);
+			final A data = cacheArrayLoader.loadArray(Cast.unchecked(dataBlock), cellDims);
+			return new Cell<>(cellDims, cellMin, data);
+		}
+		else
+			return missingLoader.get(key);
+	}
+
+	private static class ArrayDataAccessLoader<P, A> {
+
+		private final IntFunction<P> createPrimitiveArray;
+		private final Function<P, A> createArrayAccess;
+
+		ArrayDataAccessLoader(
+				final IntFunction<P> createPrimitiveArray,
+				final Function<P, A> createArrayAccess) {
+			this.createPrimitiveArray = createPrimitiveArray;
+			this.createArrayAccess = createArrayAccess;
+		}
+
+		public A loadArray(final DataBlock<P> dataBlock, final int[] cellDimensions) {
+			final int[] dataBlockSize = dataBlock.getSize();
+			if (Arrays.equals(dataBlockSize, cellDimensions)) {
+				return createArrayAccess.apply(dataBlock.getData());
+			} else {
+				final P data = createPrimitiveArray.apply((int) Intervals.numElements(cellDimensions));
+				final P src = dataBlock.getData();
+				final int[] pos = new int[dataBlockSize.length];
+				final int[] size = new int[dataBlockSize.length];
+				Arrays.setAll(size, d -> Math.min(dataBlockSize[d], cellDimensions[d]));
+				ndArrayCopy(src, dataBlockSize, pos, data, cellDimensions, pos, size);
+				return createArrayAccess.apply(data);
+			}
+		}
+	}
+
+	private static <T extends NativeType<T>> ArrayDataAccessLoader createN5CacheArrayLoader(
+			final T type,
+			final Set<AccessFlags> accessFlags) {
+
+		final boolean dirty = accessFlags.contains(DIRTY);
+		final boolean volatil = accessFlags.contains(VOLATILE);
+		final PrimitiveType primitiveType = type.getNativeTypeFactory().getPrimitiveType();
+		switch (primitiveType) {
+		case BYTE:
+			return new ArrayDataAccessLoader<>(byte[]::new,
+					dirty
+						? volatil
+							? data -> new DirtyVolatileByteArray(data, true)
+							: data -> new DirtyByteArray(data)
+						: volatil
+							? data -> new VolatileByteArray(data, true)
+							: data -> new ByteArray(data));
+		case SHORT:
+			return new ArrayDataAccessLoader<>(short[]::new,
+					dirty
+						? volatil
+							? data -> new DirtyVolatileShortArray(data, true)
+							: data -> new DirtyShortArray(data)
+						: volatil
+							? data -> new VolatileShortArray(data, true)
+							: data -> new ShortArray(data));
+		case INT:
+			return new ArrayDataAccessLoader<>(int[]::new,
+					dirty
+						? volatil
+							? data -> new DirtyVolatileIntArray(data, true)
+							: data -> new DirtyIntArray(data)
+						: volatil
+							? data -> new VolatileIntArray(data, true)
+							: data -> new IntArray(data));
+		case LONG:
+			return new ArrayDataAccessLoader<>(long[]::new,
+					dirty
+						? volatil
+							? data -> new DirtyVolatileLongArray(data, true)
+							: data -> new DirtyLongArray(data)
+						: volatil
+							? data -> new VolatileLongArray(data, true)
+							: data -> new LongArray(data));
+		case FLOAT:
+			return new ArrayDataAccessLoader<>(float[]::new,
+					dirty
+						? volatil
+							? data -> new DirtyVolatileFloatArray(data, true)
+							: data -> new DirtyFloatArray(data)
+						: volatil
+							? data -> new VolatileFloatArray(data, true)
+							: data -> new FloatArray(data));
+		case DOUBLE:
+			return new ArrayDataAccessLoader<>(double[]::new,
+					dirty
+						? volatil
+							? data -> new DirtyVolatileDoubleArray(data, true)
+							: data -> new DirtyDoubleArray(data)
+						: volatil
+							? data -> new VolatileDoubleArray(data, true)
+							: data -> new DoubleArray(data));
+		default:
+			throw new IllegalArgumentException();
+		}
+	}
+
+	/**
+	 * Like `System.arrayCopy()` but for flattened nD arrays.
+	 *
+	 * @param src
+	 * 		the (flattened) source array.
+	 * @param srcSize
+	 * 		dimensions of the source array.
+	 * @param srcPos
+	 * 		starting position in the source array.
+	 * @param dest
+	 * 		the (flattened destination array.
+	 * @param destSize
+	 * 		dimensions of the source array.
+	 * @param destPos
+	 * 		starting position in the destination data.
+	 * @param size
+	 * 		the number of array elements to be copied.
+	 */
+	// TODO: This will be moved to a new imglib2-blk artifact later. Re-use it from there when that happens.
+	private static <T> void ndArrayCopy(
+			final T src, final int[] srcSize, final int[] srcPos,
+			final T dest, final int[] destSize, final int[] destPos,
+			final int[] size) {
+		final int n = srcSize.length;
+		int srcStride = 1;
+		int destStride = 1;
+		int srcOffset = 0;
+		int destOffset = 0;
+		for (int d = 0; d < n; ++d) {
+			srcOffset += srcStride * srcPos[d];
+			srcStride *= srcSize[d];
+			destOffset += destStride * destPos[d];
+			destStride *= destSize[d];
+		}
+		ndArrayCopy(n - 1, src, srcSize, srcOffset, dest, destSize, destOffset, size);
+	}
+
+	private static <T> void ndArrayCopy(
+			final int d,
+			final T src, final int[] srcSize, final int srcPos,
+			final T dest, final int[] destSize, final int destPos,
+			final int[] size) {
+		if (d == 0)
+			System.arraycopy(src, srcPos, dest, destPos, size[d]);
+		else {
+			int srcStride = 1;
+			int destStride = 1;
+			for (int dd = 0; dd < d; ++dd) {
+				srcStride *= srcSize[dd];
+				destStride *= destSize[dd];
+			}
+
+			final int w = size[d];
+			for (int x = 0; x < w; ++x) {
+				ndArrayCopy(d - 1,
+						src, srcSize, srcPos + x * srcStride,
+						dest, destSize, destPos + x * destStride,
+						size);
+			}
+		}
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
@@ -50,11 +50,11 @@ import net.imglib2.Interval;
 import net.imglib2.IterableInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.cache.Cache;
+import net.imglib2.cache.CacheLoader;
 import net.imglib2.cache.LoaderCache;
 import net.imglib2.cache.img.CachedCellImg;
 import net.imglib2.cache.img.DiskCachedCellImgFactory;
 import net.imglib2.cache.img.DiskCachedCellImgOptions;
-import net.imglib2.cache.img.LoadedCellCacheLoader;
 import net.imglib2.cache.ref.BoundedSoftRefLoaderCache;
 import net.imglib2.cache.ref.SoftRefLoaderCache;
 import net.imglib2.exception.ImgLibException;
@@ -364,7 +364,7 @@ public class N5Utils {
 	 * remainder.
 	 *
 	 * @param max the max coordinate of the dataset
-	 * @param offse the block offsett
+	 * @param offset the block offsett
 	 * @param gridOffset the grid offset
 	 * @param blockDimensions the block dimensions
 	 * @param croppedBlockDimensions the cropped block dimensions as a long array
@@ -706,13 +706,10 @@ public class N5Utils {
 		final DatasetAttributes attributes = n5.getDatasetAttributes(dataset);
 		final long[] dimensions = attributes.getDimensions();
 		final int[] blockSize = attributes.getBlockSize();
-
-		final N5CellLoader<T> loader = new N5CellLoader<>(n5, dataset, blockSize, blockNotFoundHandler);
-
 		final CellGrid grid = new CellGrid(dimensions, blockSize);
-
-		final Cache<Long, Cell<A>> cache = loaderCache.withLoader(LoadedCellCacheLoader.get(grid, loader, type, accessFlags));
-		final CachedCellImg img = new CachedCellImg(grid, type, cache, ArrayDataAccessFactory.get(type, accessFlags));
+		final CacheLoader<Long, Cell<A>> loader = new N5CacheLoader<>(n5, dataset, grid, type, accessFlags, blockNotFoundHandler);
+		final Cache<Long, Cell<A>> cache = loaderCache.withLoader(loader);
+		final CachedCellImg<T, A> img = new CachedCellImg<>(grid, type, cache, ArrayDataAccessFactory.get(type, accessFlags));
 		return img;
 	}
 


### PR DESCRIPTION
This is done by using a CacheLoader instead of a CellLoader.

For expanded/truncated blocks we still need to make a copy (of the overlap
with the cell). Copying is done on flattened array using System.arrayCopy,
so it should be faster than before.