### PR TITLE
Fix IDE warnings

### DIFF
--- a/src/main/java/net/imglib2/realtransform/RealInvertibleComponentMappingTransform.java
+++ b/src/main/java/net/imglib2/realtransform/RealInvertibleComponentMappingTransform.java
@@ -32,9 +32,9 @@ public class RealInvertibleComponentMappingTransform extends RealComponentMappin
 
 	private static int[] checkAndFillComponent(final int[] component, int nd) {
 
-		final TreeSet<Integer> sortedIndexes = new TreeSet<Integer>();
-		for (int i = 0; i < component.length; i++) {
-			sortedIndexes.add(component[i]);
+		final TreeSet<Integer> sortedIndexes = new TreeSet<>();
+		for (int i : component) {
+			sortedIndexes.add(i);
 		}
 		final int max = sortedIndexes.last();
 		if (max > nd - 1)
@@ -49,7 +49,7 @@ public class RealInvertibleComponentMappingTransform extends RealComponentMappin
 	private static int[] buildNewComponent(final int[] component, final TreeSet<Integer> sortedIndexes, final int nd) {
 
 		final TreeSet<Integer> missingIndexes = new TreeSet<>();
-		IntStream.range(0, nd).forEach(i -> missingIndexes.add(i));
+		IntStream.range(0, nd).forEach(missingIndexes::add);
 		missingIndexes.removeAll(sortedIndexes);
 
 		final int[] compOut = new int[nd];

--- a/src/main/java/net/imglib2/realtransform/StackedRealTransform.java
+++ b/src/main/java/net/imglib2/realtransform/StackedRealTransform.java
@@ -26,8 +26,8 @@ public class StackedRealTransform implements RealTransform {
 			ns += t.numSourceDimensions();
 			nt += t.numTargetDimensions();
 
-			maxDim = ns > maxDim ? ns : maxDim;
-			maxDim = nt > maxDim ? nt : maxDim;
+			maxDim = Math.max(ns, maxDim);
+			maxDim = Math.max(nt, maxDim);
 		}
 		tmpSrc = new double[maxDim];
 		tmpTgt = new double[maxDim];

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5CellLoader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5CellLoader.java
@@ -192,8 +192,8 @@ public class N5CellLoader<T extends NativeType<T>> implements CellLoader<T> {
 					final byte[] data = (byte[])b.getData();
 					@SuppressWarnings("unchecked")
 					final Cursor<? extends GenericByteType<?>> c = (Cursor<? extends GenericByteType<?>>)a.cursor();
-					for (int i = 0; i < data.length; ++i)
-						c.next().setByte(data[i]);
+					for (byte datum : data)
+						c.next().setByte(datum);
 				} else
 					copyIntersection(a, b, dataType);
 			};
@@ -204,8 +204,8 @@ public class N5CellLoader<T extends NativeType<T>> implements CellLoader<T> {
 					final short[] data = (short[])b.getData();
 					@SuppressWarnings("unchecked")
 					final Cursor<? extends GenericShortType<?>> c = (Cursor<? extends GenericShortType<?>>)a.cursor();
-					for (int i = 0; i < data.length; ++i)
-						c.next().setShort(data[i]);
+					for (short datum : data)
+						c.next().setShort(datum);
 				} else
 					copyIntersection(a, b, dataType);
 			};
@@ -216,8 +216,8 @@ public class N5CellLoader<T extends NativeType<T>> implements CellLoader<T> {
 					final int[] data = (int[])b.getData();
 					@SuppressWarnings("unchecked")
 					final Cursor<? extends GenericIntType<?>> c = (Cursor<? extends GenericIntType<?>>)a.cursor();
-					for (int i = 0; i < data.length; ++i)
-						c.next().setInt(data[i]);
+					for (int datum : data)
+						c.next().setInt(datum);
 				} else
 					copyIntersection(a, b, dataType);
 			};
@@ -228,8 +228,8 @@ public class N5CellLoader<T extends NativeType<T>> implements CellLoader<T> {
 					final long[] data = (long[])b.getData();
 					@SuppressWarnings("unchecked")
 					final Cursor<? extends GenericLongType<?>> c = (Cursor<? extends GenericLongType<?>>)a.cursor();
-					for (int i = 0; i < data.length; ++i)
-						c.next().setLong(data[i]);
+					for (long datum : data)
+						c.next().setLong(datum);
 				} else
 					copyIntersection(a, b, dataType);
 			};
@@ -239,8 +239,8 @@ public class N5CellLoader<T extends NativeType<T>> implements CellLoader<T> {
 					final float[] data = (float[])b.getData();
 					@SuppressWarnings("unchecked")
 					final Cursor<? extends FloatType> c = (Cursor<? extends FloatType>)a.cursor();
-					for (int i = 0; i < data.length; ++i)
-						c.next().set(data[i]);
+					for (float datum : data)
+						c.next().set(datum);
 				} else
 					copyIntersection(a, b, dataType);
 			};
@@ -250,8 +250,8 @@ public class N5CellLoader<T extends NativeType<T>> implements CellLoader<T> {
 					final double[] data = (double[])b.getData();
 					@SuppressWarnings("unchecked")
 					final Cursor<? extends DoubleType> c = (Cursor<? extends DoubleType>)a.cursor();
-					for (int i = 0; i < data.length; ++i)
-						c.next().set(data[i]);
+					for (double datum : data)
+						c.next().set(datum);
 				} else
 					copyIntersection(a, b, dataType);
 			};

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5DisplacementField.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5DisplacementField.java
@@ -393,14 +393,7 @@ public class N5DisplacementField {
 		final RandomAccessibleInterval<T> source_permuted = vectorAxisFirst(source);
 		final RandomAccessibleInterval<Q> source_quant = Converters.convert(
 				source_permuted,
-				new Converter<T, Q>() {
-
-					@Override
-					public void convert(final T input, final Q output) {
-
-						output.setInteger(Math.round(input.getRealDouble() / m));
-					}
-				},
+				(input, output) -> output.setInteger(Math.round(input.getRealDouble() / m)),
 				outputType.copy());
 
 		N5Utils.save(source_quant, n5Writer, dataset, blockSize, compression);
@@ -828,19 +821,11 @@ public class N5DisplacementField {
 			m = 1.0;
 
 		final RandomAccessibleInterval<Q> src_perm = vectorAxisLast(src);
-		final RandomAccessibleInterval<T> src_converted = Converters.convert(
+
+		return Converters.convert(
 				src_perm,
-				new Converter<Q, T>() {
-
-					@Override
-					public void convert(final Q input, final T output) {
-
-						output.setReal(input.getRealDouble() * m);
-					}
-				},
+				(input, output) -> output.setReal(input.getRealDouble() * m),
 				defaultType.copy());
-
-		return src_converted;
 	}
 
 	/**
@@ -930,7 +915,7 @@ public class N5DisplacementField {
 		final MixedTransform t = new MixedTransform(n, n);
 		t.setComponentMapping(p);
 
-		return Views.interval(new MixedTransformView<T>(source, t), min, max);
+		return Views.interval(new MixedTransformView<>(source, t), min, max);
 	}
 
 	/**

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisets.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisets.java
@@ -760,12 +760,10 @@ public class N5LabelMultisets {
 				Views.flatIterable(source),
 				(int)Intervals.numElements(source));
 
-		final ByteArrayDataBlock dataBlock = new ByteArrayDataBlock(
+		return new ByteArrayDataBlock(
 				Intervals.dimensionsAsIntArray(source),
 				gridPosition,
 				data);
-
-		return dataBlock;
 	}
 
 	/**
@@ -781,7 +779,7 @@ public class N5LabelMultisets {
 	 *            the default label
 	 * @return the data block
 	 */
-	private static final ByteArrayDataBlock createNonEmptyDataBlock(
+	private static ByteArrayDataBlock createNonEmptyDataBlock(
 			final RandomAccessibleInterval<LabelMultisetType> source,
 			final long[] gridPosition,
 			final long defaultLabelId) {

--- a/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/imglib2/N5Utils.java
@@ -105,25 +105,25 @@ public class N5Utils {
 
 	public static final <T extends NativeType<T>> DataType dataType(final T type) {
 
-		if (DoubleType.class.isInstance(type))
+		if (type instanceof DoubleType)
 			return DataType.FLOAT64;
-		if (FloatType.class.isInstance(type))
+		if (type instanceof FloatType)
 			return DataType.FLOAT32;
-		if (LongType.class.isInstance(type))
+		if (type instanceof LongType)
 			return DataType.INT64;
-		if (UnsignedLongType.class.isInstance(type))
+		if (type instanceof UnsignedLongType)
 			return DataType.UINT64;
-		if (IntType.class.isInstance(type))
+		if (type instanceof IntType)
 			return DataType.INT32;
-		if (UnsignedIntType.class.isInstance(type))
+		if (type instanceof UnsignedIntType)
 			return DataType.UINT32;
-		if (ShortType.class.isInstance(type))
+		if (type instanceof ShortType)
 			return DataType.INT16;
-		if (UnsignedShortType.class.isInstance(type))
+		if (type instanceof UnsignedShortType)
 			return DataType.UINT16;
-		if (ByteType.class.isInstance(type))
+		if (type instanceof ByteType)
 			return DataType.INT8;
-		if (UnsignedByteType.class.isInstance(type))
+		if (type instanceof UnsignedByteType)
 			return DataType.UINT8;
 		else
 			return null;
@@ -175,7 +175,7 @@ public class N5Utils {
 	 * @return the data block
 	 */
 	@SuppressWarnings("unchecked")
-	private static final DataBlock<?> createDataBlock(
+	private static DataBlock<?> createDataBlock(
 			final RandomAccessibleInterval<?> source,
 			final DataType dataType,
 			final int[] intBlockSize,
@@ -262,7 +262,7 @@ public class N5Utils {
 	 * @return the data block
 	 */
 	@SuppressWarnings("unchecked")
-	private static final <T extends Type<T>> DataBlock<?> createNonEmptyDataBlock(
+	private static <T extends Type<T>> DataBlock<?> createNonEmptyDataBlock(
 			final RandomAccessibleInterval<?> source,
 			final DataType dataType,
 			final int[] intBlockSize,
@@ -789,7 +789,6 @@ public class N5Utils {
 	 *            the type
 	 * @return the image
 	 */
-	@SuppressWarnings({"unchecked", "rawtypes"})
 	public static final <T extends NativeType<T>, A extends ArrayDataAccess<A>> CachedCellImg<T, A> open(
 			final N5Reader n5,
 			final String dataset,
@@ -804,8 +803,7 @@ public class N5Utils {
 		final CellGrid grid = new CellGrid(dimensions, blockSize);
 		final CacheLoader<Long, Cell<A>> loader = new N5CacheLoader<>(n5, dataset, grid, type, accessFlags, blockNotFoundHandler);
 		final Cache<Long, Cell<A>> cache = loaderCache.withLoader(loader);
-		final CachedCellImg<T, A> img = new CachedCellImg<>(grid, type, cache, ArrayDataAccessFactory.get(type, accessFlags));
-		return img;
+		return new CachedCellImg<>(grid, type, cache, ArrayDataAccessFactory.get(type, accessFlags));
 	}
 
 	/**
@@ -889,8 +887,7 @@ public class N5Utils {
 			final double[] scale = new double[dimensions.length];
 			if (downsamplingFactors == null) {
 				final int si = 1 << s;
-				for (int i = 0; i < scale.length; ++i)
-					scale[i] = si;
+				Arrays.fill(scale, si);
 			} else {
 				for (int i = 0; i < scale.length; ++i)
 					scale[i] = downsamplingFactors[i];
@@ -935,9 +932,7 @@ public class N5Utils {
 				n5,
 				group,
 				useVolatileAccess,
-				s -> {
-					return N5CellLoader.setToDefaultValue(defaultValueSupplier.apply(s));
-				});
+				s -> N5CellLoader.setToDefaultValue(defaultValueSupplier.apply(s)));
 	}
 
 	/**

--- a/src/test/java/net/imglib2/realtransform/CoordinateMappingTest.java
+++ b/src/test/java/net/imglib2/realtransform/CoordinateMappingTest.java
@@ -14,7 +14,6 @@ public class CoordinateMappingTest {
 		final int[] perm = new int[]{1, 0};
 		final RealComponentMappingTransform xfm = new RealComponentMappingTransform(3, perm);
 
-		final double[] xOrig = new double[]{7, 5, 3};
 		final double[] x = new double[]{7, 5, 3};
 		final double[] y = new double[2];
 

--- a/src/test/java/net/imglib2/realtransform/InvertibleCoordinateMappingTest.java
+++ b/src/test/java/net/imglib2/realtransform/InvertibleCoordinateMappingTest.java
@@ -12,7 +12,6 @@ public class InvertibleCoordinateMappingTest {
 		final int[] perm = new int[]{1, 2, 0};
 		final RealInvertibleComponentMappingTransform xfm = new RealInvertibleComponentMappingTransform(perm);
 
-		final double[] xOrig = new double[]{7, 5, 3};
 		final double[] x = new double[]{7, 5, 3};
 		final double[] y = new double[3];
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5DatasetViewerExample.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5DatasetViewerExample.java
@@ -56,7 +56,7 @@ public class N5DatasetViewerExample {
 		mainT(args);
 	}
 
-	public static final <T extends NativeType<T>> void mainT(final String... args) throws IOException {
+	public static final <T extends NativeType<T>> void mainT(final String... args) {
 
 		final N5Reader n5Reader = new N5FSReader(args[0]);
 		Bdv bdv = null;

--- a/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5DisplacementFieldTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5DisplacementFieldTest.java
@@ -25,7 +25,7 @@ import net.imglib2.view.composite.RealComposite;
 
 public class N5DisplacementFieldTest {
 
-	static private String testDirPath = System.getProperty("user.home") + "/tmp/n5-imglib2-test";
+	static private final String testDirPath = System.getProperty("user.home") + "/tmp/n5-imglib2-test";
 
 	@Test
 	public void testDfieldSaveLoad() {
@@ -92,14 +92,12 @@ public class N5DisplacementFieldTest {
 		final Random r = new Random();
 		return new FunctionRealRandomAccessible<>(3,
 				(x, v) -> {
-					r.setSeed((long)Math.round(x.getDoublePosition(0) + sz[0] * x.getDoublePosition(1) + sz[0] * sz[1] * x.getDoublePosition(2)));
+					r.setSeed(Math.round(x.getDoublePosition(0) + sz[0] * x.getDoublePosition(1) + sz[0] * sz[1] * x.getDoublePosition(2)));
 					v.setPosition(r.nextDouble(), 0);
 					v.setPosition(r.nextDouble(), 1);
 					v.setPosition(r.nextDouble(), 2);
 				},
-				() -> {
-					return DoubleType.createVector(3);
-				});
+				() -> DoubleType.createVector(3));
 	}
 
 	// public static RealRandomAccessible< RealComposite< DoubleType > >

--- a/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisetsTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5LabelMultisetsTest.java
@@ -57,13 +57,13 @@ import net.imglib2.view.Views;
 
 public class N5LabelMultisetsTest {
 
-	static private String testDirPath = System.getProperty("user.home") + "/tmp/n5-imglib2-test";
+	static private final String testDirPath = System.getProperty("user.home") + "/tmp/n5-imglib2-test";
 
-	static private String datasetName = "/test/group/dataset/label";
+	static private final String datasetName = "/test/group/dataset/label";
 
-	static private long[] dimensions = new long[]{11, 22, 33};
+	static private final long[] dimensions = new long[]{11, 22, 33};
 
-	static private int[] blockSize = new int[]{5, 7, 9};
+	static private final int[] blockSize = new int[]{5, 7, 9};
 
 	static private RandomAccessibleInterval<LabelMultisetType> expectedImg;
 
@@ -94,7 +94,7 @@ public class N5LabelMultisetsTest {
 	}
 
 	@AfterClass
-	public static void rampDownAfterClass() throws Exception {
+	public static void rampDownAfterClass() {
 
 		Assert.assertTrue(n5.remove(""));
 	}

--- a/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5UtilsTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/imglib2/N5UtilsTest.java
@@ -26,6 +26,7 @@
  */
 package org.janelia.saalfeldlab.n5.imglib2;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -70,13 +71,13 @@ import net.imglib2.view.Views;
 
 public class N5UtilsTest {
 
-	static private String testDirPath = System.getProperty("user.home") + "/tmp/n5-imglib2-test";
+	static private final String testDirPath = System.getProperty("user.home") + "/tmp/n5-imglib2-test";
 
-	static private String datasetName = "/test/group/dataset";
+	static private final String datasetName = "/test/group/dataset";
 
-	static private long[] dimensions = new long[]{11, 22, 33};
+	static private final long[] dimensions = new long[]{11, 22, 33};
 
-	static private int[] blockSize = new int[]{5, 7, 9};
+	static private final int[] blockSize = new int[]{5, 7, 9};
 
 	static short[] data;
 
@@ -119,16 +120,16 @@ public class N5UtilsTest {
 	}
 
 	@AfterClass
-	public static void rampDownAfterClass() throws Exception {
+	public static void rampDownAfterClass() {
 
 		n5.remove("");
 	}
 
 	@Before
-	public void setUp() throws Exception {}
+	public void setUp() {}
 
 	@After
-	public void tearDown() throws Exception {}
+	public void tearDown() {}
 
 	@Test
 	public void testSaveAndOpen() throws InterruptedException, ExecutionException {
@@ -174,7 +175,7 @@ public class N5UtilsTest {
 	}
 
 	@Test
-	public void testOpenWithBoundedSoftRefCache() throws IOException {
+	public void testOpenWithBoundedSoftRefCache() {
 
 		// existing dataset
 		{
@@ -208,7 +209,7 @@ public class N5UtilsTest {
 	}
 
 	@Test
-	public void testVolatileOpenWithBoundedSoftRefCache() throws IOException {
+	public void testVolatileOpenWithBoundedSoftRefCache() {
 
 		// existing dataset
 		{
@@ -274,7 +275,7 @@ public class N5UtilsTest {
 	}
 
 	@Test
-	public void testBlockSize() throws IOException {
+	public void testBlockSize() {
 
 		n5.remove(datasetName);
 		final DatasetAttributes datasetAttributes = new DatasetAttributes(
@@ -310,7 +311,7 @@ public class N5UtilsTest {
 
 		int i = 0;
 		for (final UnsignedShortType t : interval000)
-			assertTrue(t.getShort() == excessData[i++]);
+			assertEquals(t.getShort(), excessData[i++]);
 
 		final IntervalView<UnsignedShortType> interval001 = Views
 				.interval(
@@ -318,7 +319,6 @@ public class N5UtilsTest {
 						new long[]{0, 0, blockSize[2]},
 						new long[]{blockSize[0] - 1, blockSize[1] - 1, blockSize[2] + blockSize[2] - 1});
 
-		i = 0;
 		final ArrayImg<UnsignedShortType, ShortArray> referenceDataImg = ArrayImgs
 				.unsignedShorts(
 						excessData,


### PR DESCRIPTION
While familiarizing myself with the repo to ultimately add convenience methods for saving/loading `String` arrays, I cleaned up some IDE warnings. I was very conservative with cleaning; in particular, I didn't delete:
* casts to a templated type since, in my experience, they're there for a reason,
* methods/classes without usages,
* deprecated API calls.

All changes were purely mechanical by the IDE, so there shouldn't be much (if any) potential for errors. 