### PR TITLE
POM: Remove unnecessary dependency on jackson-jq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,15 +201,10 @@
 			<version>${bigdataviewer-vistools-test.version}</version>
 			<scope>test</scope>
 		</dependency>
-				<dependency>
+        <dependency>
 			<groupId>se.sawano.java</groupId>
 			<artifactId>alphanumeric-comparator</artifactId>
 			<version>${alphanumeric-comparator.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>net.thisptr</groupId>
-			<artifactId>jackson-jq</artifactId>
-			<version>1.0.0-preview.20191208</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This PR removes the dependency on jackson-jq from the POM. That package is not used anywhere in the code and pulls in some ancient (~2019) dependencies.