### PR TITLE
Addition of getType() API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>37.0.0</version>
+		<version>38.0.1</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -146,9 +146,12 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
-		<n5.version>3.2.0</n5.version>
-		<bigdataviewer-core-test.version>10.4.14</bigdataviewer-core-test.version>
-		<bigdataviewer-vistools-test.version>1.0.0-beta-34</bigdataviewer-vistools-test.version>
+		<n5.version>3.3.0</n5.version>
+		<imglib2.version>7.1.0</imglib2.version>
+		<imglib2-cache.version>1.0.0-beta-18</imglib2-cache.version>
+		<imglib2-realtransform.version>4.0.3</imglib2-realtransform.version>
+		<bigdataviewer-core-test.version>10.6.0</bigdataviewer-core-test.version>
+		<bigdataviewer-vistools-test.version>1.0.0-beta-36</bigdataviewer-vistools-test.version>
 		<alphanumeric-comparator.version>1.4.1</alphanumeric-comparator.version>
 	</properties>
 


### PR DESCRIPTION
Bump to latest pom-scijava and bump imglib2 and bdv versions.

A binary incompatibility was introduced in ImgLib2 which basically requires re-compilation of n5-imglib2:

`Views.flatIterable(...)` returns `RandomAccessibleInterval` instead of `IterableInterval`. The reasoning is that `RandomAccessibleInterval` extends `IterableInterval` (since imglib2-7.0.0), and there is no reason to strip the RandomAccess part from the flatIterable result.

This is a pre-requisite for https://github.com/saalfeldlab/bigwarp/pull/170 and https://github.com/saalfeldlab/n5-ij/pull/89.